### PR TITLE
Changed runtimes/erlang-R16B02.conf to build the erlang version-R16B0…

### DIFF
--- a/runtimes/erlang-R16B02.conf
+++ b/runtimes/erlang-R16B02.conf
@@ -1,10 +1,10 @@
 name:      "erlang"
-version:   "R16B03"
+version:   "R16B02"
 namespace: "/apcera/pkg/runtimes"
 
 sources [
-  { url: "https://s3.amazonaws.com/apcera-sources/erlang/otp_src_R16B03.tar.gz",
-    sha256: "6133b3410681a5c934e54c76eee1825f96dead8d6a12c31a64f6e160daf0bb06" },
+  { url: "https://s3.amazonaws.com/apcera-sources/erlang/otp_src_R16B02.tar.gz",
+    sha256: "6ab8ad1df8185345554a4b80e10fd8be06c4f2b71b69dcfb8528352787b32f85" },
 ]
 
 build_depends [ { package: "build-essential" } ]
@@ -12,16 +12,16 @@ depends  [ { os: "ubuntu" } ]
 
 provides [ { runtime: "erlang" },
            { runtime: "erlang-R16B" },
-           { runtime: "erlang-R16B03" }]
+           { runtime: "erlang-R16B02" }]
 
-environment { "PATH": "/opt/apcera/erlang-R16B03/bin:$PATH" }
+environment { "PATH": "/opt/apcera/erlang-R16B02/bin:$PATH" }
 
 build (
       export INSTALLPATH=/opt/apcera/erlang-R16B02
 
-      tar -zxf otp-OTP_R16B03.tar.gz
+      tar -zxf otp_src_R16B02.tar.gz
       sudo mkdir -p ${INSTALLPATH}
-      cd otp-OTP_R16B03
+      cd otp_src_R16B02
       ./otp_build autoconf --prefix=${INSTALLPATH}
       ./configure --prefix=${INSTALLPATH}
       echo "Running Make"


### PR DESCRIPTION
…2 correctly.

Earlier, this conf file was downloading another erlang version and installing
the incorrect version. Now, it downloads and installs the version R16B02.

@variadico 