### PR TITLE
Add name flag to package build example

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ These are the package config scripts we use to build the runtimes available in t
 Using these definitions can be done through the use of APC:
 
 ```console
-$ apc package build runtimes/go-1.5.1.conf
+$ apc package build runtimes/go-1.5.1.conf --name go-1.5.1
 ```
 
 This will use the package definition to generate a build script, upload that to


### PR DESCRIPTION
If people `apc package build` multiple versions of a runtime without `--name`, they will end up overwriting the previous build. If they only build one version, they will wonder why `go-1.5.1` didn't appear in `package list -ns /`.

@zquestz 