### PR TITLE
This removes the version field from all build scripts.

### DIFF
--- a/deb/td-agent-1.1.17-amd64.conf
+++ b/deb/td-agent-1.1.17-amd64.conf
@@ -1,5 +1,4 @@
-name:    "td-agent"
-version: "1.1.17-1-amd64"
+name:    "td-agent-1.1.17-1-amd64"
 namespace: "/apcera/pkg/packages"
 
 sources [

--- a/legacy/os/ubuntu-13.04-build-essential.conf
+++ b/legacy/os/ubuntu-13.04-build-essential.conf
@@ -1,5 +1,4 @@
-name:    "ubuntu-build-essential"
-version: "13.04"
+name:    "ubuntu-build-essential-13.04"
 
 depends  [ { os: "ubuntu-13.04" } ]
 provides [ { package: "build-essential" } ]

--- a/legacy/os/ubuntu-13.04.conf
+++ b/legacy/os/ubuntu-13.04.conf
@@ -1,5 +1,4 @@
-name:    "ubuntu"
-version: "13.04"
+name:    "ubuntu-13.04"
 
 sources [
   { url: "http://apcera-sources.s3.amazonaws.com/os/debootstrap_1.0.46_all.deb",

--- a/legacy/packages/apache-2.2.25.conf
+++ b/legacy/packages/apache-2.2.25.conf
@@ -1,5 +1,4 @@
-name:    "apache"
-version: "2.2.25"
+name:    "apache-2.2.25"
 
 sources [
   { url: "https://apcera-sources.s3.amazonaws.com/apache/httpd-2.2.25.tar.gz",

--- a/legacy/packages/apache-2.2.27.conf
+++ b/legacy/packages/apache-2.2.27.conf
@@ -1,5 +1,4 @@
-name:      "apache"
-version:   "2.2.27"
+name:      "apache-2.2.27"
 namespace: "/apcera/pkg/packages"
 
 sources [

--- a/legacy/packages/apache-ant-1.9.2.conf
+++ b/legacy/packages/apache-ant-1.9.2.conf
@@ -1,5 +1,4 @@
-name:    "apache-ant"
-version: "1.9.2"
+name:    "apache-ant-1.9.2"
 
 sources [
   { url: "https://s3.amazonaws.com/apcera-sources/java/apache-ant-1.9.2-bin.tar.gz",

--- a/legacy/packages/apache-tomcat-7.0.47.conf
+++ b/legacy/packages/apache-tomcat-7.0.47.conf
@@ -1,5 +1,4 @@
-name:    "apache-tomcat"
-version: "7.0.47"
+name:    "apache-tomcat-7.0.47"
 
 sources [
   { url: "https://s3.amazonaws.com/apcera-sources/java/apache-tomcat-7.0.47.tar.gz",

--- a/legacy/packages/git-1.8.4.2.conf
+++ b/legacy/packages/git-1.8.4.2.conf
@@ -1,5 +1,4 @@
-name:    "git"
-version: "1.8.4.2"
+name:    "git-1.8.4.2"
 
 sources [
   { url: "https://apcera-sources.s3.amazonaws.com/git/git-1.8.4.2.tar.gz",

--- a/legacy/packages/git-2.0.3.conf
+++ b/legacy/packages/git-2.0.3.conf
@@ -1,5 +1,4 @@
-name:      "git"
-version:   "2.0.3"
+name:      "git-2.0.3"
 namespace: "/apcera/pkg/packages"
 
 sources [

--- a/legacy/packages/imagemagick-6.8.9-6.conf
+++ b/legacy/packages/imagemagick-6.8.9-6.conf
@@ -1,5 +1,4 @@
-name:      "imagemagick"
-version:   "6.8.9-6"
+name:      "imagemagick-6.8.9-6"
 namespace: "/apcera/pkg/packages"
 
 sources [

--- a/legacy/packages/mercurial-2.8.conf
+++ b/legacy/packages/mercurial-2.8.conf
@@ -1,5 +1,4 @@
-name:    "mercurial"
-version: "2.8-rc"
+name:    "mercurial-2.8-rc"
 
 sources [
   { url: "https://apcera-sources.s3.amazonaws.com/mercurial/mercurial-2.8-rc.tar.gz",

--- a/legacy/packages/redis-2.8.17.conf
+++ b/legacy/packages/redis-2.8.17.conf
@@ -1,5 +1,4 @@
-name:      "redis"
-version:   "2.8.17"
+name:      "redis-2.8.17"
 namespace: "/apcera/pkg/packages"
 
 sources [

--- a/legacy/packages/subversion-1.8.4.conf
+++ b/legacy/packages/subversion-1.8.4.conf
@@ -1,5 +1,4 @@
-name:    "subversion"
-version: "1.8.4"
+name:    "subversion-1.8.4"
 
 sources [
   { url: "https://s3.amazonaws.com/apcera-sources/subversion/subversion-1.8.4.tar.gz",

--- a/legacy/packages/zsh-5.0.7.conf
+++ b/legacy/packages/zsh-5.0.7.conf
@@ -1,5 +1,4 @@
-name:      "zsh"
-version:   "5.0.7"
+name:      "zsh-5.0.7"
 namespace: "/apcera/pkg/packages"
 
 sources [

--- a/legacy/runtimes/go-1.1.1.conf
+++ b/legacy/runtimes/go-1.1.1.conf
@@ -1,5 +1,4 @@
-name:    "go"
-version: "1.1.1"
+name:    "go-1.1.1"
 
 sources [
   { url: "https://apcera-sources.s3.amazonaws.com/go/go1.1.1.linux-amd64.tar.gz",

--- a/legacy/runtimes/go-1.1.2.conf
+++ b/legacy/runtimes/go-1.1.2.conf
@@ -1,5 +1,4 @@
-name:    "go"
-version: "1.1.2"
+name:    "go-1.1.2"
 
 sources [
   { url: "https://apcera-sources.s3.amazonaws.com/go/go1.1.2.linux-amd64.tar.gz",

--- a/legacy/runtimes/node-0.10.21.conf
+++ b/legacy/runtimes/node-0.10.21.conf
@@ -1,5 +1,4 @@
-name:    "node"
-version: "0.10.21"
+name:    "node-0.10.21"
 
 sources [
   { url: "https://apcera-sources.s3.amazonaws.com/node/node-v0.10.21.tar.gz",

--- a/legacy/runtimes/node-0.10.33.conf
+++ b/legacy/runtimes/node-0.10.33.conf
@@ -1,5 +1,4 @@
-name:      "node"
-version:   "0.10.33"
+name:      "node0.10.33"
 namespace: "/apcera/pkg/runtimes"
 
 sources [

--- a/legacy/runtimes/perl-5.18.1.conf
+++ b/legacy/runtimes/perl-5.18.1.conf
@@ -1,5 +1,4 @@
-name:    "perl"
-version: "5.18.1"
+name:    "perl-5.18.1"
 
 sources [
   { url: "https://apcera-sources.s3.amazonaws.com/perl/perl-5.18.1.tar.gz",

--- a/legacy/runtimes/php-5.4.23.conf
+++ b/legacy/runtimes/php-5.4.23.conf
@@ -1,5 +1,4 @@
-name:    "php"
-version: "5.4.23"
+name:    "php-5.4.23"
 
 # See ../Verification.md for release verification
 

--- a/legacy/runtimes/php-5.4.31.conf
+++ b/legacy/runtimes/php-5.4.31.conf
@@ -1,5 +1,4 @@
-name:      "php"
-version:   "5.4.31"
+name:      "php-5.4.31"
 namespace: "/apcera/pkg/runtimes"
 
 # See ../Verification.md for release verification

--- a/legacy/runtimes/php-apache-5.5.15.conf
+++ b/legacy/runtimes/php-apache-5.5.15.conf
@@ -1,5 +1,4 @@
-name:      "php-apache"
-version:   "5.5.15"
+name:      "php-apache-5.5.15"
 namespace: "/apcera/pkg/runtimes"
 
 # See ../Verification.md for release verification

--- a/legacy/runtimes/php-apache-5.5.7.conf
+++ b/legacy/runtimes/php-apache-5.5.7.conf
@@ -1,5 +1,4 @@
-name:    "php-apache"
-version: "5.5.7"
+name:    "php-apache-5.5.7"
 
 # See ../Verification.md for release verification
 

--- a/legacy/runtimes/php-fpm-nginx-5.5.15.conf
+++ b/legacy/runtimes/php-fpm-nginx-5.5.15.conf
@@ -1,5 +1,4 @@
-name:      "php-fpm-nginx"
-version:   "5.5.15"
+name:      "php-fpm-nginx-5.5.15"
 namespace: "/apcera/pkg/runtimes"
 
 # -apc1 for freetype-2.5.3 security update

--- a/legacy/runtimes/php-fpm-nginx-5.5.7.conf
+++ b/legacy/runtimes/php-fpm-nginx-5.5.7.conf
@@ -1,5 +1,4 @@
-name:    "php-fpm-nginx"
-version: "5.5.7"
+name:    "php-fpm-nginx-5.5.7"
 
 # See ../Verification.md for release verification
 

--- a/legacy/runtimes/python-2.7.5.conf
+++ b/legacy/runtimes/python-2.7.5.conf
@@ -1,5 +1,4 @@
-name:    "python"
-version: "2.7.5"
+name:    "python-2.7.5"
 
 sources [
   { url: "https://apcera-sources.s3.amazonaws.com/python/Python-2.7.5.tgz",

--- a/legacy/runtimes/python-2.7.8.conf
+++ b/legacy/runtimes/python-2.7.8.conf
@@ -1,5 +1,4 @@
-name:      "python"
-version:   "2.7.8"
+name:      "python-2.7.8"
 namespace: "/apcera/pkg/runtimes"
 
 sources [

--- a/legacy/runtimes/python-3.3.2.conf
+++ b/legacy/runtimes/python-3.3.2.conf
@@ -1,5 +1,4 @@
-name:    "python"
-version: "3.3.2"
+name:    "python-3.3.2"
 
 sources [
   { url: "https://apcera-sources.s3.amazonaws.com/python/Python-3.3.2.tgz",

--- a/legacy/runtimes/python-3.3.5.conf
+++ b/legacy/runtimes/python-3.3.5.conf
@@ -1,5 +1,4 @@
-name:      "python"
-version:   "3.3.5"
+name:      "python-3.3.5"
 namespace: "/apcera/pkg/runtimes"
 
 sources [

--- a/legacy/runtimes/python-3.4.1.conf
+++ b/legacy/runtimes/python-3.4.1.conf
@@ -1,5 +1,4 @@
-name:      "python"
-version:   "3.4.1"
+name:      "python-3.4.1"
 namespace: "/apcera/pkg/runtimes"
 
 sources [

--- a/legacy/runtimes/ruby-2.0.0-p481.conf
+++ b/legacy/runtimes/ruby-2.0.0-p481.conf
@@ -1,5 +1,4 @@
-name:      "ruby"
-version:   "2.0.0-p481"
+name:      "ruby-2.0.0-p481"
 namespace: "/apcera/pkg/runtimes"
 
 sources [

--- a/legacy/runtimes/ruby-2.1.2.conf
+++ b/legacy/runtimes/ruby-2.1.2.conf
@@ -1,5 +1,4 @@
-name:      "ruby"
-version:   "2.1.2"
+name:      "ruby-2.1.2"
 namespace: "/apcera/pkg/runtimes"
 
 sources [

--- a/legacy/runtimes/ruby-2.1.5.conf
+++ b/legacy/runtimes/ruby-2.1.5.conf
@@ -1,5 +1,4 @@
-name:      "ruby"
-version:   "2.1.5"
+name:      "ruby-2.1.5"
 namespace: "/apcera/pkg/runtimes"
 
 sources [

--- a/os/ubuntu-12.04-build-essential.conf
+++ b/os/ubuntu-12.04-build-essential.conf
@@ -1,5 +1,4 @@
-name:      "ubuntu-build-essential"
-version:   "12.04"
+name:      "ubuntu-build-essential-12.04"
 namespace: "/apcera/pkg/os"
 
 depends  [ { os: "ubuntu-12.04" } ]

--- a/os/ubuntu-12.04.conf
+++ b/os/ubuntu-12.04.conf
@@ -1,5 +1,4 @@
-name:      "ubuntu"
-version:   "12.04"
+name:      "ubuntu-12.04"
 namespace: "/apcera/pkg/os"
 
 sources [

--- a/os/ubuntu-13.10-apc1.conf
+++ b/os/ubuntu-13.10-apc1.conf
@@ -1,5 +1,4 @@
-name:      "ubuntu"
-version:   "13.10"
+name:      "ubuntu-13.10"
 namespace: "/apcera/pkg/os"
 
 sources [

--- a/os/ubuntu-13.10-build-essential.conf
+++ b/os/ubuntu-13.10-build-essential.conf
@@ -1,5 +1,4 @@
-name:      "ubuntu-build-essential"
-version:   "13.10"
+name:      "ubuntu-build-essential-13.10"
 namespace: "/apcera/pkg/os"
 
 depends  [ { os: "ubuntu-13.10" } ]

--- a/os/ubuntu-14.04-apc1.conf
+++ b/os/ubuntu-14.04-apc1.conf
@@ -1,5 +1,4 @@
-name:      "ubuntu"
-version:   "14.04-apc1"
+name:      "ubuntu-14.04-apc1"
 namespace: "/apcera/pkg/os"
 
 sources [

--- a/os/ubuntu-14.04-build-essential.conf
+++ b/os/ubuntu-14.04-build-essential.conf
@@ -1,5 +1,4 @@
-name:      "ubuntu-build-essential"
-version:   "14.04"
+name:      "ubuntu-build-essential-14.04"
 namespace: "/apcera/pkg/os"
 
 depends  [ { os: "ubuntu-14.04" } ]

--- a/packages/apache-2.2.29.conf
+++ b/packages/apache-2.2.29.conf
@@ -1,5 +1,4 @@
-name:      "apache"
-version:   "2.2.29"
+name:      "apache-2.2.29"
 namespace: "/apcera/pkg/packages"
 
 sources [

--- a/packages/apache-ant-1.9.4.conf
+++ b/packages/apache-ant-1.9.4.conf
@@ -1,5 +1,4 @@
-name:      "apache-ant"
-version:   "1.9.4"
+name:      "apache-ant-1.9.4"
 namespace: "/apcera/pkg/packages"
 
 sources [

--- a/packages/apache-tomcat-7.0.55.conf
+++ b/packages/apache-tomcat-7.0.55.conf
@@ -1,5 +1,4 @@
-name:      "apache-tomcat"
-version:   "7.0.55"
+name:      "apache-tomcat-7.0.55"
 namespace: "/apcera/pkg/packages"
 
 sources [

--- a/packages/apc-0.16.0.conf
+++ b/packages/apc-0.16.0.conf
@@ -1,5 +1,4 @@
-name:      "apc"
-version    "0.16.0"
+name:      "apc-0.16.0"
 namespace: "/apcera/pkg/packages"
 
 sources [

--- a/packages/bzr-2.6.0.conf
+++ b/packages/bzr-2.6.0.conf
@@ -1,5 +1,4 @@
-name:        "bzr"
-version:     "2.6.0"
+name:        "bzr-2.6.0"
 namespace:   "/apcera/pkg/packages"
 description: "Bazaar version control system"
 
@@ -29,7 +28,3 @@ build (
       echo "Installing bzr"
       sudo -E bash -c "PATH=$PATH PYTHONHOME=$PYTHONHOME PYTHONPATH=$PYTHONPATH && python setup.py install"
 )
-
-
-
-

--- a/packages/git-2.3.1.conf
+++ b/packages/git-2.3.1.conf
@@ -1,5 +1,4 @@
-name:      "git"
-version:   "2.3.1"
+name:      "git-2.3.1"
 namespace: "/apcera/pkg/packages"
 
 sources [

--- a/packages/imagemagick-6.8.9-6-apc2.conf
+++ b/packages/imagemagick-6.8.9-6-apc2.conf
@@ -1,5 +1,4 @@
-name:      "imagemagick"
-version:   "6.8.9-6-apc2"
+name:      "imagemagick-6.8.9-6-apc2"
 namespace: "/apcera/pkg/packages"
 
 sources [

--- a/packages/maven-3.2.2.conf
+++ b/packages/maven-3.2.2.conf
@@ -1,5 +1,4 @@
-name:      "maven"
-version:   "3.2.2"
+name:      "maven-3.2.2"
 namespace: "/apcera/pkg/packages"
 
 sources [

--- a/packages/memcached-1.4.20.conf
+++ b/packages/memcached-1.4.20.conf
@@ -1,5 +1,4 @@
-name:      "memcached"
-version:   "1.4.20"
+name:      "memcached-1.4.20"
 namespace: "/apcera/pkg/packages"
 
 sources [

--- a/packages/mercurial-3.0.2.conf
+++ b/packages/mercurial-3.0.2.conf
@@ -1,5 +1,4 @@
-name:      "mercurial"
-version:   "3.0.2"
+name:      "mercurial-3.0.2"
 namespace: "/apcera/pkg/packages"
 
 sources [

--- a/packages/mysql-5.6.25.conf
+++ b/packages/mysql-5.6.25.conf
@@ -1,5 +1,4 @@
-name:      "mysql"
-version:   "5.6.25"
+name:      "mysql-5.6.25"
 namespace: "/apcera/pkg/packages"
 
 sources [

--- a/packages/newrelic-java-3.20.0.conf
+++ b/packages/newrelic-java-3.20.0.conf
@@ -1,5 +1,4 @@
-name:      "newrelic-java"
-version:   "3.20.0"
+name:      "newrelic-java-3.20.0"
 namespace: "/apcera/pkg/packages"
 
 sources [

--- a/packages/nginx-1.6.0.conf
+++ b/packages/nginx-1.6.0.conf
@@ -1,5 +1,4 @@
-name:      "nginx"
-version:   "1.6.0"
+name:      "nginx-1.6.0"
 namespace: "/apcera/pkg/packages"
 
 sources [

--- a/packages/ovftool-4.1.0.conf
+++ b/packages/ovftool-4.1.0.conf
@@ -1,5 +1,4 @@
-name:      "ovftool"
-version:   "4.1.0"
+name:      "ovftool-4.1.0"
 namespace: "/apcera/pkg/packages"
 
 # Build is from: https://www.vmware.com/support/developer/ovf/

--- a/packages/rabbitmq-3.5.5.conf
+++ b/packages/rabbitmq-3.5.5.conf
@@ -1,5 +1,4 @@
-name:      "rabbitmq"
-version:   "3.5.5"
+name:      "rabbitmq-3.5.5"
 namespace: "/apcera/pkg/packages"
 
 sources [

--- a/packages/redis-2.8.13.conf
+++ b/packages/redis-2.8.13.conf
@@ -1,5 +1,4 @@
-name:      "redis"
-version:   "2.8.13"
+name:      "redis-2.8.13"
 namespace: "/apcera/pkg/packages"
 
 sources [

--- a/packages/rsync-3.1.1.conf
+++ b/packages/rsync-3.1.1.conf
@@ -1,5 +1,4 @@
-name:      "rsync"
-version:   "3.1.1"
+name:      "rsync-3.1.1"
 namespace: "/apcera/pkg/packages"
 
 sources [

--- a/packages/subversion-1.8.9.conf
+++ b/packages/subversion-1.8.9.conf
@@ -1,5 +1,4 @@
-name:      "subversion"
-version:   "1.8.9"
+name:      "subversion-1.8.9"
 namespace: "/apcera/pkg/packages"
 
 sources [

--- a/packages/tokumx-2.0.1.conf
+++ b/packages/tokumx-2.0.1.conf
@@ -1,5 +1,4 @@
-name:      "tokumx"
-version:   "2.0.1"
+name:      "tokumx-2.0.1"
 namespace: "/apcera/pkg/packages"
 
 sources [
@@ -18,7 +17,7 @@ provides      [ { package: "mongodb" },
 environment { "PATH": "/opt/apcera/tokumx-2.0.1-linux-x86_64/bin:$PATH" }
 
 build (
-  
+
   # Create install dir
   export INSTALLPATH=/opt/apcera
   mkdir -p $INSTALLPATH

--- a/packages/zsh-5.0.5.conf
+++ b/packages/zsh-5.0.5.conf
@@ -1,5 +1,4 @@
-name:      "zsh"
-version:   "5.0.5"
+name:      "zsh-5.0.5"
 namespace: "/apcera/pkg/packages"
 
 sources [

--- a/runtimes/clisp-2.49.conf
+++ b/runtimes/clisp-2.49.conf
@@ -1,5 +1,4 @@
-name:      "clisp"
-version:   "2.49"
+name:      "clisp-2.49"
 namespace: "/apcera/pkg/runtimes"
 
 sources [

--- a/runtimes/erlang-R16B02.conf
+++ b/runtimes/erlang-R16B02.conf
@@ -1,5 +1,4 @@
-name:      "erlang"
-version:   "R16B02"
+name:      "erlang-R16B02"
 namespace: "/apcera/pkg/runtimes"
 
 sources [

--- a/runtimes/erlang-R16B03.conf
+++ b/runtimes/erlang-R16B03.conf
@@ -1,5 +1,4 @@
-name:      "erlang"
-version:   "R16B03"
+name:      "erlang-R16B03"
 namespace: "/apcera/pkg/runtimes"
 
 sources [

--- a/runtimes/erlang-otp1701.conf
+++ b/runtimes/erlang-otp1701.conf
@@ -1,5 +1,4 @@
-name:      "erlang"
-version:   "OTP-17.1"
+name:      "erlang-OTP-17.1"
 namespace: "/apcera/pkg/runtimes"
 
 sources [

--- a/runtimes/go-1.2.conf
+++ b/runtimes/go-1.2.conf
@@ -1,5 +1,4 @@
-name:      "go"
-version:   "1.2"
+name:      "go-1.2"
 namespace: "/apcera/pkg/runtimes"
 
 sources [

--- a/runtimes/go-1.3.conf
+++ b/runtimes/go-1.3.conf
@@ -1,5 +1,4 @@
-name:      "go"
-version:   "1.3"
+name:      "go-1.3"
 namespace: "/apcera/pkg/runtimes"
 
 sources [

--- a/runtimes/go-1.4.conf
+++ b/runtimes/go-1.4.conf
@@ -1,5 +1,4 @@
-name:      "go"
-version:   "1.4"
+name:      "go-1.4"
 namespace: "/apcera/pkg/runtimes"
 
 sources [

--- a/runtimes/go-1.5.1.conf
+++ b/runtimes/go-1.5.1.conf
@@ -1,5 +1,4 @@
-name:      "go"
-version:   "1.5.1"
+name:      "go-1.5.1"
 namespace: "/apcera/pkg/runtimes"
 
 sources [

--- a/runtimes/java-8.conf
+++ b/runtimes/java-8.conf
@@ -1,9 +1,8 @@
-name:      "jdk-1.8.0"
-version:   "8u60"
+name:      "jdk-1.8.0-8u60"
 namespace: "/apcera/pkg/runtimes"
 
 # Build is from: http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html
-# The license agreement must be accepted so it assumes the file is 
+# The license agreement must be accepted so it assumes the file is
 # located in the same folder as this configuration file.
 include_files [ "jdk-8u60-linux-x64.gz" ]
 

--- a/runtimes/meteor-1.2.0.1.conf
+++ b/runtimes/meteor-1.2.0.1.conf
@@ -1,5 +1,4 @@
-name:      "meteor"
-version:   "1.2.0.1"
+name:      "meteor-1.2.0.1"
 namespace: "/apcera/pkg/runtimes"
 
 sources [

--- a/runtimes/node-0.10.40.conf
+++ b/runtimes/node-0.10.40.conf
@@ -1,5 +1,4 @@
-name:      "node"
-version:   "0.10.40"
+name:      "node-0.10.40"
 namespace: "/apcera/pkg/runtimes"
 
 sources [

--- a/runtimes/node-0.6.21.conf
+++ b/runtimes/node-0.6.21.conf
@@ -1,5 +1,4 @@
-name:      "node"
-version:   "0.6.21"
+name:      "node-0.6.21"
 namespace: "/apcera/pkg/runtimes"
 
 sources [

--- a/runtimes/node-0.8.28.conf
+++ b/runtimes/node-0.8.28.conf
@@ -1,5 +1,4 @@
-name:      "node"
-version:   "0.8.28"
+name:      "node-0.8.28"
 namespace: "/apcera/pkg/runtimes"
 
 sources [

--- a/runtimes/node-4.2.1.conf
+++ b/runtimes/node-4.2.1.conf
@@ -1,5 +1,4 @@
-name:      "node"
-version:   "4.2.1"
+name:      "node-4.2.1"
 namespace: "/apcera/pkg/runtimes"
 
 sources [

--- a/runtimes/ocaml-4.01.0.conf
+++ b/runtimes/ocaml-4.01.0.conf
@@ -1,5 +1,4 @@
-name:      "ocaml"
-version:   "4.01.0"
+name:      "ocaml-4.01.0"
 namespace: "/apcera/pkg/runtimes"
 
 sources [

--- a/runtimes/openjdk-1.6.conf
+++ b/runtimes/openjdk-1.6.conf
@@ -1,5 +1,4 @@
-name:      "openjdk"
-version:   "1.6.0-b31"
+name:      "openjdk-1.6.0-b31"
 namespace: "/apcera/pkg/runtimes"
 
 # Build is from: https://github.com/alexkasko/openjdk-unofficial-builds

--- a/runtimes/openjdk-1.7.conf
+++ b/runtimes/openjdk-1.7.conf
@@ -1,5 +1,4 @@
-name:      "openjdk"
-version:   "1.7.0-u60-b30"
+name:      "openjdk-1.7.0-u60-b30"
 namespace: "/apcera/pkg/runtimes"
 
 # Build is from: https://github.com/alexkasko/openjdk-unofficial-builds

--- a/runtimes/perl-5.14.4.conf
+++ b/runtimes/perl-5.14.4.conf
@@ -1,5 +1,4 @@
-name:      "perl"
-version:   "5.14.4"
+name:      "perl-5.14.4"
 namespace: "/apcera/pkg/runtimes"
 
 sources [

--- a/runtimes/perl-5.16.3.conf
+++ b/runtimes/perl-5.16.3.conf
@@ -1,5 +1,4 @@
-name:      "perl"
-version:   "5.16.3"
+name:      "perl-5.16.3"
 namespace: "/apcera/pkg/runtimes"
 
 sources [

--- a/runtimes/perl-5.18.2.conf
+++ b/runtimes/perl-5.18.2.conf
@@ -1,5 +1,4 @@
-name:      "perl"
-version:   "5.18.2"
+name:      "perl-5.18.2"
 namespace: "/apcera/pkg/runtimes"
 
 sources [

--- a/runtimes/perl-5.20.0.conf
+++ b/runtimes/perl-5.20.0.conf
@@ -1,5 +1,4 @@
-name:      "perl"
-version:   "5.20.0"
+name:      "perl-5.20.0"
 namespace: "/apcera/pkg/runtimes"
 
 sources [

--- a/runtimes/php-5.4.31-apc3.conf
+++ b/runtimes/php-5.4.31-apc3.conf
@@ -1,5 +1,4 @@
-name:      "php"
-version:   "5.4.31-apc3"
+name:      "php-5.4.31-apc3"
 namespace: "/apcera/pkg/runtimes"
 
 # See ../Verification.md for release verification

--- a/runtimes/php-apache-5.5.15-apc5.conf
+++ b/runtimes/php-apache-5.5.15-apc5.conf
@@ -1,5 +1,4 @@
-name:      "php-apache"
-version:   "5.5.15-apc5"
+name:      "php-apache-5.5.15-apc5"
 namespace: "/apcera/pkg/runtimes"
 
 # See ../Verification.md for release verification

--- a/runtimes/php-fpm-nginx-5.5.15-apc4.conf
+++ b/runtimes/php-fpm-nginx-5.5.15-apc4.conf
@@ -1,5 +1,4 @@
-name:      "php-fpm-nginx"
-version:   "5.5.15-apc4"
+name:      "php-fpm-nginx-5.5.15-apc4"
 namespace: "/apcera/pkg/runtimes"
 
 # -apc4 for libpng 1.6.19 security update
@@ -149,7 +148,7 @@ build (
 
         sudo ${INSTALLPATH:?}/bin/pecl install memcache
         sudo bash -c "echo 'extension=memcache.so' >> php.ini"
-        
+
         sudo ${INSTALLPATH:?}/bin/pecl install uploadprogress
         sudo bash -c "echo 'extension=uploadprogress.so' >> php.ini"
       )

--- a/runtimes/python-2.7.9.conf
+++ b/runtimes/python-2.7.9.conf
@@ -1,5 +1,4 @@
-name:      "python"
-version:   "2.7.9"
+name:      "python-2.7.9"
 namespace: "/apcera/pkg/runtimes"
 
 sources [

--- a/runtimes/python-3.3.6.conf
+++ b/runtimes/python-3.3.6.conf
@@ -1,5 +1,4 @@
-name:      "python"
-version:   "3.3.6"
+name:      "python-3.3.6"
 namespace: "/apcera/pkg/runtimes"
 
 sources [

--- a/runtimes/python-3.4.3.conf
+++ b/runtimes/python-3.4.3.conf
@@ -1,5 +1,4 @@
-name:      "python"
-version:   "3.4.3"
+name:      "python-3.4.3"
 namespace: "/apcera/pkg/runtimes"
 
 sources [

--- a/runtimes/ruby-1.8.7-p374.conf
+++ b/runtimes/ruby-1.8.7-p374.conf
@@ -1,5 +1,4 @@
-name:      "ruby"
-version:   "1.8.7-p374"
+name:      "ruby-1.8.7-p374"
 namespace: "/apcera/pkg/runtimes"
 
 sources [

--- a/runtimes/ruby-1.9.3-p547.conf
+++ b/runtimes/ruby-1.9.3-p547.conf
@@ -1,5 +1,4 @@
-name:      "ruby"
-version:   "1.9.3-p547"
+name:      "ruby-1.9.3-p547"
 namespace: "/apcera/pkg/runtimes"
 
 sources [

--- a/runtimes/ruby-2.0.0-p643.conf
+++ b/runtimes/ruby-2.0.0-p643.conf
@@ -1,5 +1,4 @@
-name:      "ruby"
-version:   "2.0.0-p643"
+name:      "ruby-2.0.0-p643"
 namespace: "/apcera/pkg/runtimes"
 
 sources [

--- a/runtimes/ruby-2.1.5-apc1.conf
+++ b/runtimes/ruby-2.1.5-apc1.conf
@@ -1,5 +1,4 @@
-name:      "ruby"
-version:   "2.1.5-apc1"
+name:      "ruby-2.1.5-apc1"
 namespace: "/apcera/pkg/runtimes"
 
 sources [

--- a/runtimes/ruby-2.2.3.conf
+++ b/runtimes/ruby-2.2.3.conf
@@ -1,5 +1,4 @@
-name:      "ruby"
-version:   "2.2.3"
+name:      "ruby-2.2.3"
 namespace: "/apcera/pkg/runtimes"
 
 sources [


### PR DESCRIPTION
The version field within build scripts was never used/leveraged by anything in
the stager. If anything, it was originally meant as metadata for the person
looking at the file. However, this means it confuses people who assume since it
it is there, it is used.

This removes all version fields from build scripts and instead appends the
version to the package name which is used when building the package.

@gabrieljackson @zquestz 