### PR TITLE
Add Postgres start script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.cntmp
 *.bundle
+.DS_Store

--- a/packages/postgres-9.4.4.conf
+++ b/packages/postgres-9.4.4.conf
@@ -18,34 +18,18 @@ environment { "PATH": "/opt/apcera/postgres-9.4.4/bin:$PATH" }
 build (
   export INSTALLPATH=/opt/apcera/postgres-9.4.4
 
-  tar xvzf postgresql-9.4.4.tar.gz
-  cd postgresql-9.4.4
-
-  ./configure --prefix=${INSTALLPATH} --with-openssl
-  make
-  make install
-  adduser postgres --gecos GECOS --disabled-password
-  mkdir ${INSTALLPATH}/data
-  chown postgres ${INSTALLPATH}/data
-  sudo -u postgres ${INSTALLPATH}/bin/initdb -D ${INSTALLPATH}/data --encoding=UTF8
-  sudo -u postgres ${INSTALLPATH}/bin/postgres -D ${INSTALLPATH}/data > logfile 2>&1 &
-
-  sleep 5
-
-  sudo -u postgres ${INSTALLPATH}/bin/psql postgres -c "ALTER USER postgres WITH PASSWORD 'postgres';"
-
-  echo "listen_addresses = '0.0.0.0'" >> ${INSTALLPATH}/data/postgresql.conf
-  echo "ssl = on" >> ${INSTALLPATH}/data/postgresql.conf
-  echo "host all all 0.0.0.0/0 md5" >> ${INSTALLPATH}/data/pg_hba.conf
-
-  sudo pkill postgres
-
+  ##
+  # Define helper script to install certs in data/
+  ##
+  cat > install_certs.sh <<'_EOF'
+#!/bin/sh
+  export INSTALLPATH=/opt/apcera/postgres-9.4.4
   cd ${INSTALLPATH}/data
 
   # Certs are hard coded because interactive setup of openssl keys requires user input.
   # Feel free to add your own certs. Here are the docs:
   # http://www.postgresql.org/docs/9.4/static/ssl-tcp.html
-  cat > server.crt <<'_EOF'
+  cat > server.crt <<EOF
 Certificate:
     Data:
         Version: 3 (0x2)
@@ -80,12 +64,12 @@ Certificate:
                     0c:55
                 Exponent: 65537 (0x10001)
         X509v3 extensions:
-            X509v3 Subject Key Identifier: 
+            X509v3 Subject Key Identifier:
                 17:4E:54:B0:8D:2E:3E:F2:5B:73:EE:B5:E5:81:66:A9:A1:F0:25:1E
-            X509v3 Authority Key Identifier: 
+            X509v3 Authority Key Identifier:
                 keyid:17:4E:54:B0:8D:2E:3E:F2:5B:73:EE:B5:E5:81:66:A9:A1:F0:25:1E
 
-            X509v3 Basic Constraints: 
+            X509v3 Basic Constraints:
                 CA:TRUE
     Signature Algorithm: sha256WithRSAEncryption
          17:af:df:d0:e5:00:66:9e:83:e3:93:cd:b9:d5:b5:aa:b7:0a:
@@ -125,8 +109,8 @@ a3Dn0fgklA/z2Tka7NZqdkUYLBQax6jChHH9Dm7MiWWOyjf8zsrsaDBp8iIxfSmd
 V714JnlDccBEItxuXVbtT9eqmY73sayRP0X0ZhJOzVUq8mKV+oRl2Kekh8kOLOmG
 VnxgtWReU+Z0G2maawgfthvgZ4NoXUFQ0lDaVJo=
 -----END CERTIFICATE-----
-_EOF
-cat > server.key <<'_EOF'
+EOF
+  cat > server.key <<EOF
 -----BEGIN RSA PRIVATE KEY-----
 MIIEpAIBAAKCAQEAuuIEVr8Q4p16K4S8aVnlamRQUNm3c5jhikMJGslv9G2nEMwA
 gInfNE7TW56YJypIj8f8nGubuHVXjp/D9W4OsWNpVxLxOM9sEOFtA5SM4zRSOAZC
@@ -154,8 +138,8 @@ RnseqwKBgQCkDKNE9kZOYtj+biPsPogL89HJWFEwXPSL3P82CfpHQOgfM3VC+8Tj
 KeCr/PULkjSo4WvFWVzzzTR7E3w6MM0MRov9q/X8grMel9bhlqNqhdoQdxFA8naX
 sdAxqqP3pqAQBqAqV04iJdDSFlo0IebLVKQrAGy416bni5yE2wS3RQ==
 -----END RSA PRIVATE KEY-----
-_EOF
-  cat > server.req <<'_EOF'
+EOF
+  cat > server.req <<EOF
 Certificate Request:
     Data:
         Version: 0 (0x0)
@@ -218,7 +202,71 @@ qFf+BLKy1qhZUjK7Fnb7hCS1/MHm8nKXVgutb1BLj1QFoibm6RUhFeWWUDN4E6EL
 0IadRQ8LHbIw8E8PM3XSYxsiHd3+Xgs1xb5QJRf/aD/8kPaH8Iz17AxV9QeGL9qG
 qC+F74jyMzou7KcaBw28LmgeocE=
 -----END CERTIFICATE REQUEST-----
-_EOF
+EOF
   chown postgres:postgres server.*
   chmod og-rwx server.key
+_EOF
+  chmod +x install_certs.sh
+
+  ##
+  # Define helper script to reinitialize database after NFS bind.
+  ##
+  cat > start_pg.sh <<'_EOF'
+#!/bin/sh
+
+export INSTALLPATH=/opt/apcera/postgres-9.4.4
+
+chown -R postgres:postgres ${INSTALLPATH}/data
+chmod 0700 ${INSTALLPATH}/data
+
+if [ $(find ${INSTALLPATH}/data -maxdepth 0 -type d -empty 2>/dev/null) ]; then
+  sudo -u postgres ${INSTALLPATH}/bin/initdb -D ${INSTALLPATH}/data --encoding=UTF8
+  sudo -u postgres ${INSTALLPATH}/bin/postgres -D ${INSTALLPATH}/data > logfile 2>&1 &
+
+  sleep 5
+
+  sudo -u postgres ${INSTALLPATH}/bin/psql postgres -c "ALTER USER postgres WITH PASSWORD 'postgres';"
+
+  echo "listen_addresses = '0.0.0.0'" >> ${INSTALLPATH}/data/postgresql.conf
+  echo "ssl = on" >> ${INSTALLPATH}/data/postgresql.conf
+  echo "host all all 0.0.0.0/0 md5" >> ${INSTALLPATH}/data/pg_hba.conf
+
+  # If script is called start_postgres.sh, then pkill will exit the script here.
+  sudo pkill postgres
+
+  ${INSTALLPATH}/bin/install_certs.sh
+fi
+
+sudo -u postgres ${INSTALLPATH}/bin/postgres -D ${INSTALLPATH}/data
+_EOF
+  chmod +x start_pg.sh
+
+  tar xvzf postgresql-9.4.4.tar.gz
+  cd postgresql-9.4.4
+
+  ./configure --prefix=${INSTALLPATH} --with-openssl
+  make
+  make install
+
+  cd ..
+  mv install_certs.sh ${INSTALLPATH}/bin
+  mv start_pg.sh ${INSTALLPATH}/bin
+
+  adduser postgres --gecos GECOS --disabled-password
+  mkdir -p ${INSTALLPATH}/data
+  chown postgres:postgres ${INSTALLPATH}/data
+  sudo -u postgres ${INSTALLPATH}/bin/initdb -D ${INSTALLPATH}/data --encoding=UTF8
+  sudo -u postgres ${INSTALLPATH}/bin/postgres -D ${INSTALLPATH}/data > logfile 2>&1 &
+
+  sleep 5
+
+  sudo -u postgres ${INSTALLPATH}/bin/psql postgres -c "ALTER USER postgres WITH PASSWORD 'postgres';"
+
+  echo "listen_addresses = '0.0.0.0'" >> ${INSTALLPATH}/data/postgresql.conf
+  echo "ssl = on" >> ${INSTALLPATH}/data/postgresql.conf
+  echo "host all all 0.0.0.0/0 md5" >> ${INSTALLPATH}/data/pg_hba.conf
+
+  sudo pkill postgres
+
+  ${INSTALLPATH}/bin/install_certs.sh
 )


### PR DESCRIPTION
Currently, NFS persistence isn't supported for Postgres. When a user
mounts an NFS volume under Postgres' data directory, it causes the
database to fail. This adds a start script that a user could use to
reinitialize the database data directory if needed for persistence.

Resolves ENGT-4156

@zquestz