### PR TITLE
Allow any apache to be used for php, not just 2.2

### DIFF
--- a/runtimes/php-5.4.31-apc2.conf
+++ b/runtimes/php-5.4.31-apc2.conf
@@ -1,5 +1,5 @@
 name:      "php"
-version:   "5.4.31-apc1"
+version:   "5.4.31-apc2"
 namespace: "/apcera/pkg/runtimes"
 
 # See ../Verification.md for release verification
@@ -19,7 +19,7 @@ sources [
 
 build_depends [ { package: "build-essential" } ]
 depends       [ { os: "ubuntu" },
-                { package: "apache-2.2" } ]
+                { package: "apache" } ]
 provides      [ { runtime: "php" },
                 { runtime: "php-5" },
                 { runtime: "php-5.4" },

--- a/runtimes/php-apache-5.5.15-apc4.conf
+++ b/runtimes/php-apache-5.5.15-apc4.conf
@@ -1,5 +1,5 @@
 name:      "php-apache"
-version:   "5.5.15-apc3"
+version:   "5.5.15-apc4"
 namespace: "/apcera/pkg/runtimes"
 
 # See ../Verification.md for release verification
@@ -17,7 +17,7 @@ sources [
 
 build_depends [ { package: "build-essential" } ]
 depends       [ { os: "ubuntu" },
-                { package: "apache-2.2" } ]
+                { package: "apache" } ]
 provides      [ { runtime: "php" },
                 { runtime: "php-5" },
                 { runtime: "php-5.5" },


### PR DESCRIPTION
Currently QC has Apache 2.4 packages and can't use them due to an artificial limitation in our current scripts. This just allows any apache to be used, not just 2.2.

@schancel @philpennock @tw4dl 