### PR TITLE
Add cron to base OS package

### DIFF
--- a/os/ubuntu-13.10-apc1.conf
+++ b/os/ubuntu-13.10-apc1.conf
@@ -28,7 +28,7 @@ build (
 
       # make the rootfs and run debootstrap
       sudo mkdir -p /rootfs
-      sudo debootstrap --verbose --arch=amd64 --variant=minbase --include adduser,apt,bzip2,debconf,debconf-i18n,iputils-ping,less,locales,lsb-release,makedev,mawk,net-tools,netbase,netcat-openbsd,passwd,procps,sudo,tzdata,ubuntu-keyring,udev,unzip,upstart,ureadahead,whiptail,apt-transport-https,ca-certificates,curl,openssh-client,screen,wget,zip,libadns1,libbz2-1.0,libc6,libcurl3,libcurl3-gnutls,libevent-2.0-5,libevent-core-2.0-5,libevent-extra-2.0-5,libevent-openssl-2.0-5,libevent-pthreads-2.0-5,libexpat1,libgcc1,libglib2.0-0,libicu48,libncurses5,libpcre3,libpcrecpp0,libreadline6,libssl1.0.0,libstdc++6,libtinfo5,libxml2,libxslt1.1,zlib1g,libmysqlclient18,libsqlite3-0,libpq5 saucy /rootfs http://archive.ubuntu.com/ubuntu/
+      sudo debootstrap --verbose --arch=amd64 --variant=minbase --include adduser,apt,bzip2,debconf,debconf-i18n,iputils-ping,less,locales,lsb-release,makedev,mawk,net-tools,netbase,netcat-openbsd,passwd,procps,sudo,tzdata,ubuntu-keyring,udev,unzip,upstart,ureadahead,whiptail,apt-transport-https,ca-certificates,curl,openssh-client,screen,wget,zip,libadns1,libbz2-1.0,libc6,libcurl3,libcurl3-gnutls,libevent-2.0-5,libevent-core-2.0-5,libevent-extra-2.0-5,libevent-openssl-2.0-5,libevent-pthreads-2.0-5,libexpat1,libgcc1,libglib2.0-0,libicu48,libncurses5,libpcre3,libpcrecpp0,libreadline6,libssl1.0.0,libstdc++6,libtinfo5,libxml2,libxslt1.1,zlib1g,libmysqlclient18,libsqlite3-0,libpq5,cron,vim-tiny saucy /rootfs http://archive.ubuntu.com/ubuntu/
 
       # chroot in - Note the EOS at the end. This is using busybox's sh and
       # sending the contents in, so has to be fairly basic.
@@ -59,8 +59,10 @@ build (
 
         # add the runner user (uid 99)
         addgroup --gid 99 runner
-        adduser --system --no-create-home --uid 99 --gid 99 \
+        adduser --system --uid 99 --gid 99 \
           --shell /bin/bash --disabled-password runner
+
+        usermod -a -G crontab runner
 
         # enable sudo for the runner user
         echo "#99 ALL=(ALL:ALL) NOPASSWD: ALL" >> /etc/sudoers

--- a/os/ubuntu-14.04-apc1.conf
+++ b/os/ubuntu-14.04-apc1.conf
@@ -1,5 +1,5 @@
 name:      "ubuntu"
-version:   "14.04"
+version:   "14.04-apc1"
 namespace: "/apcera/pkg/os"
 
 sources [
@@ -88,12 +88,14 @@ build (
 
         # update package list
         apt-get update
-        apt-get install -f -y adduser apt bash bzip2 debconf debconf-i18n iputils-ping less locales lsb-release makedev mawk net-tools netbase netcat-openbsd passwd procps sudo tzdata ubuntu-keyring udev unzip upstart ureadahead whiptail apt-transport-https ca-certificates curl openssh-client screen wget zip libadns1 libbz2-1.0 libc6 libcurl3 libcurl3-gnutls libevent-2.0-5 libevent-core-2.0-5 libevent-extra-2.0-5 libevent-openssl-2.0-5 libevent-pthreads-2.0-5 libexpat1 libgcc1 libglib2.0-0 libicu52 libncurses5 libpcre3 libpcrecpp0 libreadline6 libssl1.0.0 libstdc++6 libtinfo5 libxml2 libxslt1.1 zlib1g libmysqlclient18 libsqlite3-0 libpq5 libgomp1
+        apt-get install -f -y adduser apt bash bzip2 debconf debconf-i18n iputils-ping less locales lsb-release makedev mawk net-tools netbase netcat-openbsd passwd procps sudo tzdata ubuntu-keyring udev unzip upstart ureadahead whiptail apt-transport-https ca-certificates curl openssh-client screen wget zip libadns1 libbz2-1.0 libc6 libcurl3 libcurl3-gnutls libevent-2.0-5 libevent-core-2.0-5 libevent-extra-2.0-5 libevent-openssl-2.0-5 libevent-pthreads-2.0-5 libexpat1 libgcc1 libglib2.0-0 libicu52 libncurses5 libpcre3 libpcrecpp0 libreadline6 libssl1.0.0 libstdc++6 libtinfo5 libxml2 libxslt1.1 zlib1g libmysqlclient18 libsqlite3-0 libpq5 libgomp1 cron vim-tiny
 
         # add the runner user (uid 99)
         addgroup --gid 99 runner
-        adduser --system --no-create-home --uid 99 --gid 99 \
+        adduser --system --uid 99 --gid 99 \
           --shell /bin/bash --disabled-password runner
+
+        usermod -a -G crontab runner
 
         # enable sudo for the runner user
         #


### PR DESCRIPTION
Added cron to the base ubuntu 14.04 image.

Since I was here I also re-enabled the /home/runner home dir, as the ruby stager requires it for git based dependencies.

@schancel @tw4dl @lilirui @mbhinder 