### PR TITLE
Use official godep

### DIFF
--- a/legacy/runtimes/go-1.1.1.conf
+++ b/legacy/runtimes/go-1.1.1.conf
@@ -32,5 +32,5 @@ build (
       # Install godeps
       export PATH=$INSTALLPATH/bin:$PATH
       export GOROOT=$INSTALLPATH
-      go get github.com/apcera/godep
+      go get github.com/tools/godep
 )

--- a/legacy/runtimes/go-1.1.2.conf
+++ b/legacy/runtimes/go-1.1.2.conf
@@ -34,5 +34,5 @@ build (
       # Install godeps
       export PATH=$INSTALLPATH/bin:$PATH
       export GOROOT=$INSTALLPATH
-      go get github.com/apcera/godep
+      go get github.com/tools/godep
 )

--- a/runtimes/go-1.2.conf
+++ b/runtimes/go-1.2.conf
@@ -34,7 +34,7 @@ build (
       # Install godeps
       export PATH=$INSTALLPATH/bin:$PATH
       export GOROOT=$INSTALLPATH
-      go get github.com/apcera/godep
+      go get github.com/tools/godep
 
       sudo chown -R runner:runner $GOPATH
       sudo chown -R runner:runner $INSTALLPATH

--- a/runtimes/go-1.3.conf
+++ b/runtimes/go-1.3.conf
@@ -34,7 +34,7 @@ build (
       # Install godeps
       export PATH=$INSTALLPATH/bin:$PATH
       export GOROOT=$INSTALLPATH
-      go get github.com/apcera/godep
+      go get github.com/tools/godep
 
       sudo chown -R runner:runner $GOPATH
       sudo chown -R runner:runner $INSTALLPATH

--- a/runtimes/go-1.4.conf
+++ b/runtimes/go-1.4.conf
@@ -34,7 +34,7 @@ build (
       # Install godeps
       export PATH=$INSTALLPATH/bin:$PATH
       export GOROOT=$INSTALLPATH
-      go get github.com/apcera/godep
+      go get github.com/tools/godep
 
       sudo chown -R runner:runner $GOPATH
       sudo chown -R runner:runner $INSTALLPATH

--- a/runtimes/go-1.5.1.conf
+++ b/runtimes/go-1.5.1.conf
@@ -34,7 +34,7 @@ build (
       # Install godeps
       export PATH=$INSTALLPATH/bin:$PATH
       export GOROOT=$INSTALLPATH
-      go get github.com/apcera/godep
+      go get github.com/tools/godep
 
       sudo chown -R runner:runner $GOPATH
       sudo chown -R runner:runner $INSTALLPATH


### PR DESCRIPTION
Our fork of apcera/godep is so old that the code.google.com is no longer up. I tried building the package with the official godep tool and everything worked fine. Is there any reason not to use the official godep repo? It seems like most people would be using the official version locally anyway.

Resolves [ENGT-5884](https://apcera.atlassian.net/browse/ENGT-5884)

@zquestz 