### PR TITLE
Unlock the perl version from 5.20

### DIFF
--- a/legacy/packages/mysql-5.6.25-apc1.conf
+++ b/legacy/packages/mysql-5.6.25-apc1.conf
@@ -17,7 +17,7 @@ sources [
 
 build_depends [ { package: "build-essential" } ]
 depends       [ { os: "ubuntu" },
-                { runtime: "perl-5.20"} ]
+                { runtime: "perl-5"} ]
 provides      [ { package: "mysql" },
                 { package: "mysql-5.6" },
                 { package: "mysql-5.6.25" } ]

--- a/packages/mysql-5.6.25-apc2.conf
+++ b/packages/mysql-5.6.25-apc2.conf
@@ -17,7 +17,7 @@ sources [
 
 build_depends [ { package: "build-essential" } ]
 depends       [ { os: "ubuntu" },
-                { runtime: "perl-5.20"} ]
+                { runtime: "perl-5"} ]
 provides      [ { package: "mysql" },
                 { package: "mysql-5.6" },
                 { package: "mysql-5.6.25" } ]


### PR DESCRIPTION
This updates the dependency of Perl package from 5.20 only to any 5.x.

@variadico @tw4dl @zquestz 