### PR TITLE
Added new mysql script which works with multiple versions of perl

### DIFF
--- a/packages/mysql-5.6.25-apc4.conf
+++ b/packages/mysql-5.6.25-apc4.conf
@@ -1,0 +1,160 @@
+# Copyright 2016 Apcera Inc. All rights reserved.
+#
+# You must give the compiler more memory and disk.
+# apc job update /apcera/stagers::compiler --memory 4G --disk 8G
+# Otherwise, you won't be able to build this package.
+#
+# If you want NFS persistence, then the start command should be this.
+# --start-cmd "sudo /opt/apcera/mysql-5.6.25/start_mysql.sh"
+
+name:      "mysql-5.6.25-apc4"
+namespace: "/apcera/pkg/packages"
+
+sources [
+  { url: "https://s3.amazonaws.com/apcera-sources/mysql/mysql-5.6.25.tar.gz",
+    sha256: "15079c0b83d33a092649cbdf402c9225bcd3f33e87388407be5cdbf1432c7fbd" },
+]
+
+build_depends [ { package: "build-essential" } ]
+depends       [ { os: "ubuntu" },
+                { runtime: "perl-5"} ]
+provides      [ { package: "mysql" },
+                { package: "mysql-5.6" },
+                { package: "mysql-5.6.25" } ]
+
+environment { "PATH": "/opt/apcera/mysql-5.6.25/bin:$PATH" }
+
+build (
+  ##
+  # Define helper script to reinitialize database after NFS bind.
+  ##
+  cat > start_mysql.sh <<'_EOF'
+#!/bin/sh
+
+INSTALLPATH=/opt/apcera/mysql-5.6.25
+MYSQL_ROOT_PASSWORD=${MYSQL_ROOT_PASSWORD:-"root"}
+
+chown -R mysql:mysql ${INSTALLPATH}/data
+chmod -R 0755 ${INSTALLPATH}/data
+
+# Check if directory is empty. (Ignores hidden files.)
+# "1" means the only path that was found is: /opt/apcera/mysql-5.6.25/data
+# Important database files are typically non-hidden. On the other hand, NFS
+# will put a hidden ".nfs001" in a mounted directory.
+if [ "$(find ${INSTALLPATH}/data -maxdepth 1 -not -path '*/\.*' | wc -l)" = "1" ]; then
+  # Reinitialize the database.
+  ${INSTALLPATH}/scripts/mysql_install_db --user=mysql --basedir=${INSTALLPATH} --datadir=${INSTALLPATH}/data --lc-messages-dir=${INSTALLPATH}/share/english/
+
+  # Start MySQL server in background.
+  ${INSTALLPATH}/bin/mysqld_safe &
+
+  sleep 5
+
+  HOSTNAME=$(hostname)
+
+  # Set default passwords for all users, local and network based.
+  ${INSTALLPATH}/bin/mysqladmin --user=root password "${MYSQL_ROOT_PASSWORD}"
+  ${INSTALLPATH}/bin/mysql --user=root --password="${MYSQL_ROOT_PASSWORD}" --execute="SET PASSWORD FOR 'root'@'${HOSTNAME}' = PASSWORD('${MYSQL_ROOT_PASSWORD}');"
+  ${INSTALLPATH}/bin/mysql --user=root --password="${MYSQL_ROOT_PASSWORD}" --execute="CREATE USER 'root'@'%' IDENTIFIED BY '${MYSQL_ROOT_PASSWORD}';"
+
+  # Allow root user to do everything when logged in from any host.
+  ${INSTALLPATH}/bin/mysql --user=root --password="${MYSQL_ROOT_PASSWORD}" --execute="GRANT ALL PRIVILEGES ON *.* TO 'root'@'${HOSTNAME}' IDENTIFIED BY '${MYSQL_ROOT_PASSWORD}' WITH GRANT OPTION; FLUSH PRIVILEGES;"
+  ${INSTALLPATH}/bin/mysql --user=root --password="${MYSQL_ROOT_PASSWORD}" --execute="GRANT ALL PRIVILEGES ON *.* TO 'root'@'%' IDENTIFIED BY '${MYSQL_ROOT_PASSWORD}' WITH GRANT OPTION; FLUSH PRIVILEGES;"
+
+  # Stop MySQL, since we don't want it to run in the background anymore.
+  pkill -9 mysqld
+fi
+
+${INSTALLPATH}/bin/mysqld_safe
+_EOF
+
+  INSTALLPATH=/opt/apcera/mysql-5.6.25
+  MYSQL_ROOT_PASSWORD="root"
+
+  # Untar mysql.
+  tar xvzf mysql-5.6.25.tar.gz
+  cd mysql-5.6.25 || exit
+
+  # Build mysql.
+  cmake -DCMAKE_INSTALL_PREFIX=${INSTALLPATH} -DENABLE_DOWNLOADS=1 -DCMAKE_C_FLAGS="-O3 -g -Wall -Wextra -Wformat-security -Wvla -Wwrite-strings -Wdeclaration-after-statement" -DCMAKE_CXX_FLAGS_RELWITHDEBINFO="-O3 -g -DDBUG_OFF" -DDEFAULT_CHARSET=utf8 -DDEFAULT_COLLATION=utf8_general_ci .
+  make -j4
+  make install
+
+  # Remove non-essential files. Reduces mysql folder by about half.
+  rm -rf ${INSTALLPATH}/docs
+  rm -rf ${INSTALLPATH}/man
+  rm -rf ${INSTALLPATH}/sql-bench
+  rm -rf ${INSTALLPATH}/mysql-test
+  rm ${INSTALLPATH}/bin/msql2mysql
+  rm ${INSTALLPATH}/bin/mysql_find_rows
+  rm ${INSTALLPATH}/bin/mysql_fix_extensions
+  rm ${INSTALLPATH}/bin/mysql_zap
+  rm ${INSTALLPATH}/bin/mysqlaccess.conf
+  rm ${INSTALLPATH}/bin/mysql_convert_table_format
+  rm ${INSTALLPATH}/bin/mysqlbug
+  rm ${INSTALLPATH}/bin/mysql_setpermission
+  rm ${INSTALLPATH}/bin/mysqlaccess
+  rm ${INSTALLPATH}/bin/mysql_waitpid
+  rm ${INSTALLPATH}/bin/mysqltest_embedded
+  rm ${INSTALLPATH}/bin/mysql_client_test_embedded
+
+  cd ..
+  mv start_mysql.sh ${INSTALLPATH}/bin
+  chmod +x ${INSTALLPATH}/bin/start_mysql.sh
+
+  # Add users and groups.
+  groupadd mysql
+  useradd -r -g mysql mysql
+
+  mkdir -p /var/log/mysql/
+  mkdir -p /var/run/mysqld/
+
+  # Make sure dirs are owned by mysql
+  chown -R mysql:mysql /var/log/mysql
+  chown -R mysql:mysql /var/run/mysqld
+
+  # Initialize db.
+  ${INSTALLPATH}/scripts/mysql_install_db --user=mysql --basedir=${INSTALLPATH} --datadir=${INSTALLPATH}/data --lc-messages-dir=${INSTALLPATH}/share/english/
+
+  {
+    # Add reasonable values to initial MySQL configuration.
+    echo "user=mysql"
+    echo "socket=/var/run/mysqld/mysqld.sock"
+    echo "pid-file=/var/run/mysqld/mysqld.pid"
+    echo "basedir=${INSTALLPATH}"
+    echo "datadir=${INSTALLPATH}/data"
+    echo "bind-address=0.0.0.0"
+    echo "lc-messages-dir=${INSTALLPATH}/share/english"
+    echo "character-set-client-handshake=FALSE"
+    echo "character-set-server=utf8mb4"
+    echo "collation-server=utf8mb4_unicode_ci"
+
+    # Appease warnings.
+    echo "explicit_defaults_for_timestamp=1"
+    echo "key_buffer_size=16M"
+  } >> ${INSTALLPATH}/my.cnf
+
+  # Start MySQL server in background
+  ${INSTALLPATH}/bin/mysqld_safe &
+
+  sleep 5
+
+  HOSTNAME=$(hostname)
+
+  # Set default passwords for all users, local and network based.
+  ${INSTALLPATH}/bin/mysqladmin --user=root password ${MYSQL_ROOT_PASSWORD}
+  ${INSTALLPATH}/bin/mysql --user=root --password=${MYSQL_ROOT_PASSWORD} --execute="SET PASSWORD FOR 'root'@'${HOSTNAME}' = PASSWORD('${MYSQL_ROOT_PASSWORD}');"
+  ${INSTALLPATH}/bin/mysql --user=root --password=${MYSQL_ROOT_PASSWORD} --execute="CREATE USER 'root'@'%' IDENTIFIED BY '${MYSQL_ROOT_PASSWORD}';"
+
+  # Allow root user to do everything when logged in from any host.
+  ${INSTALLPATH}/bin/mysql --user=root --password=${MYSQL_ROOT_PASSWORD} --execute="GRANT ALL PRIVILEGES ON *.* TO 'root'@'${HOSTNAME}' IDENTIFIED BY '${MYSQL_ROOT_PASSWORD}' WITH GRANT OPTION; FLUSH PRIVILEGES;"
+  ${INSTALLPATH}/bin/mysql --user=root --password=${MYSQL_ROOT_PASSWORD} --execute="GRANT ALL PRIVILEGES ON *.* TO 'root'@'%' IDENTIFIED BY '${MYSQL_ROOT_PASSWORD}' WITH GRANT OPTION; FLUSH PRIVILEGES;"
+
+  # Stop mysql.
+  pkill -9 mysqld
+
+  # Fixes missing File::Basename, File::Copy, Sys::Hostname, and Data::Dumper
+  # error in start_mysql.sh.
+  # Strangely, this error doesn't happen during package build.
+  sed -i "s/#!\/usr\/bin\/perl/#!\/usr\/bin\/env perl/" ${INSTALLPATH}/scripts/mysql_install_db
+)


### PR DESCRIPTION
Shebang for mysql_install_db is now `#!/usr/bin/env perl` so that it can pickup any resolved perl, instead of a hard coded one.

@tw4dl @variadico @schancel 