### PR TITLE
Add New Relic script

### DIFF
--- a/packages/newrelic-java-3.28.0.conf
+++ b/packages/newrelic-java-3.28.0.conf
@@ -1,0 +1,268 @@
+name: "newrelic-java-3.28.0"
+namespace: "/apcera/pkg/packages"
+
+sources [{
+    url: "https://apcera-sources.s3.amazonaws.com/newrelic/newrelic-java-3.28.0.zip"
+    sha256: "258b5f12b35c0a76b8605ffbd2afc4b96745c0932e8ba9cb4e780f5e719e9a71"
+}]
+
+build_depends [{package: "build-essential"}]
+
+depends [
+    {os: "linux"}
+    {package: "apache-tomcat"}
+    {runtime: "java"}
+]
+
+provides [
+    {package: "newrelic-java-3.28.0"}
+    {package: "newrelic-java-3.28"}
+    {package: "newrelic-java-3"}
+    {package: "newrelic-java"}
+]
+
+build (
+    mkdir -p $CATALINA_HOME/temp
+    chmod 777 $CATALINA_HOME/temp
+
+    unzip newrelic-java-3.28.0.zip
+
+    # In order to prevent hard-coding values, use the --env-set flag for the
+    # apc app create command and set the JAVA_OPTS environment like so:
+    # 'JAVA_OPTS=-Dnewrelic.config.license_key=YOUR_KEY -Dnewrelic.config.app_name=YOUR_APP'
+    NEW_RELIC_APP_NAME=''
+    NEW_RELIC_LICENSE_KEY=''
+    cat <<EOF > newrelic/newrelic.yml
+---
+common:
+  agent_enabled: true
+  app_name: "$NEW_RELIC_APP_NAME"
+  attributes:
+    enabled: true
+  audit_mode: false
+  browser_monitoring:
+    auto_instrument: true
+  class_transformer:
+    com.newrelic.instrumentation.servlet-user:
+      enabled: false
+    com.newrelic.instrumentation.spring-aop-2:
+      enabled: false
+  cross_application_tracer:
+    enabled: true
+  enable_auto_app_naming: false
+  enable_auto_transaction_naming: true
+  error_collector:
+    enabled: true
+    ignore_errors: akka.actor.ActorKilledException
+    ignore_status_codes: 404
+  high_security: false
+  labels: ~
+  license_key: "$NEW_RELIC_LICENSE_KEY"
+  log_daily: false
+  log_file_count: 1
+  log_file_name: newrelic_agent.log
+  log_level: info
+  log_limit_in_kbytes: 0
+  max_stack_trace_lines: 30
+  ssl: true
+  thread_profiler:
+    enabled: true
+  transaction_events:
+    enabled: true
+    max_samples_stored: 2000
+  transaction_tracer:
+    enabled: true
+    explain_enabled: true
+    explain_threshold: 0.5
+    log_sql: false
+    record_sql: obfuscated
+    stack_trace_threshold: 0.5
+    top_n: 20
+    transaction_threshold: apdex_f
+development:
+  agent_enabled: true
+  app_name: "$NEW_RELIC_APP_NAME (Development)"
+  attributes:
+    enabled: true
+  audit_mode: false
+  browser_monitoring:
+    auto_instrument: true
+  class_transformer:
+    com.newrelic.instrumentation.servlet-user:
+      enabled: false
+    com.newrelic.instrumentation.spring-aop-2:
+      enabled: false
+  cross_application_tracer:
+    enabled: true
+  enable_auto_app_naming: false
+  enable_auto_transaction_naming: true
+  error_collector:
+    enabled: true
+    ignore_errors: akka.actor.ActorKilledException
+    ignore_status_codes: 404
+  high_security: false
+  labels: ~
+  license_key: "$NEW_RELIC_LICENSE_KEY"
+  log_daily: false
+  log_file_count: 1
+  log_file_name: newrelic_agent.log
+  log_level: info
+  log_limit_in_kbytes: 0
+  max_stack_trace_lines: 30
+  ssl: true
+  thread_profiler:
+    enabled: true
+  transaction_events:
+    enabled: true
+    max_samples_stored: 2000
+  transaction_tracer:
+    enabled: true
+    explain_enabled: true
+    explain_threshold: 0.5
+    log_sql: false
+    record_sql: obfuscated
+    stack_trace_threshold: 0.5
+    top_n: 20
+    transaction_threshold: apdex_f
+production:
+  agent_enabled: true
+  app_name: "$NEW_RELIC_APP_NAME"
+  attributes:
+    enabled: true
+  audit_mode: false
+  browser_monitoring:
+    auto_instrument: true
+  class_transformer:
+    com.newrelic.instrumentation.servlet-user:
+      enabled: false
+    com.newrelic.instrumentation.spring-aop-2:
+      enabled: false
+  cross_application_tracer:
+    enabled: true
+  enable_auto_app_naming: false
+  enable_auto_transaction_naming: true
+  error_collector:
+    enabled: true
+    ignore_errors: akka.actor.ActorKilledException
+    ignore_status_codes: 404
+  high_security: false
+  labels: ~
+  license_key: "$NEW_RELIC_LICENSE_KEY"
+  log_daily: false
+  log_file_count: 1
+  log_file_name: newrelic_agent.log
+  log_level: info
+  log_limit_in_kbytes: 0
+  max_stack_trace_lines: 30
+  ssl: true
+  thread_profiler:
+    enabled: true
+  transaction_events:
+    enabled: true
+    max_samples_stored: 2000
+  transaction_tracer:
+    enabled: true
+    explain_enabled: true
+    explain_threshold: 0.5
+    log_sql: false
+    record_sql: obfuscated
+    stack_trace_threshold: 0.5
+    top_n: 20
+    transaction_threshold: apdex_f
+staging:
+  agent_enabled: true
+  app_name: "$NEW_RELIC_APP_NAME (Staging)"
+  attributes:
+    enabled: true
+  audit_mode: false
+  browser_monitoring:
+    auto_instrument: true
+  class_transformer:
+    com.newrelic.instrumentation.servlet-user:
+      enabled: false
+    com.newrelic.instrumentation.spring-aop-2:
+      enabled: false
+  cross_application_tracer:
+    enabled: true
+  enable_auto_app_naming: false
+  enable_auto_transaction_naming: true
+  error_collector:
+    enabled: true
+    ignore_errors: akka.actor.ActorKilledException
+    ignore_status_codes: 404
+  high_security: false
+  labels: ~
+  license_key: "$NEW_RELIC_LICENSE_KEY"
+  log_daily: false
+  log_file_count: 1
+  log_file_name: newrelic_agent.log
+  log_level: info
+  log_limit_in_kbytes: 0
+  max_stack_trace_lines: 30
+  ssl: true
+  thread_profiler:
+    enabled: true
+  transaction_events:
+    enabled: true
+    max_samples_stored: 2000
+  transaction_tracer:
+    enabled: true
+    explain_enabled: true
+    explain_threshold: 0.5
+    log_sql: false
+    record_sql: obfuscated
+    stack_trace_threshold: 0.5
+    top_n: 20
+    transaction_threshold: apdex_f
+test:
+  agent_enabled: true
+  app_name: "$NEW_RELIC_APP_NAME (Test)"
+  attributes:
+    enabled: true
+  audit_mode: false
+  browser_monitoring:
+    auto_instrument: true
+  class_transformer:
+    com.newrelic.instrumentation.servlet-user:
+      enabled: false
+    com.newrelic.instrumentation.spring-aop-2:
+      enabled: false
+  cross_application_tracer:
+    enabled: true
+  enable_auto_app_naming: false
+  enable_auto_transaction_naming: true
+  error_collector:
+    enabled: true
+    ignore_errors: akka.actor.ActorKilledException
+    ignore_status_codes: 404
+  high_security: false
+  labels: ~
+  license_key: "$NEW_RELIC_LICENSE_KEY"
+  log_daily: false
+  log_file_count: 1
+  log_file_name: newrelic_agent.log
+  log_level: info
+  log_limit_in_kbytes: 0
+  max_stack_trace_lines: 30
+  ssl: true
+  thread_profiler:
+    enabled: true
+  transaction_events:
+    enabled: true
+    max_samples_stored: 2000
+  transaction_tracer:
+    enabled: true
+    explain_enabled: true
+    explain_threshold: 0.5
+    log_sql: false
+    record_sql: obfuscated
+    stack_trace_threshold: 0.5
+    top_n: 20
+    transaction_threshold: apdex_f
+EOF
+
+    cp -r newrelic ${CATALINA_HOME}
+    chmod 777 -R ${CATALINA_HOME}/newrelic
+    cd ${CATALINA_HOME}/newrelic
+    java -jar newrelic.jar install
+)


### PR DESCRIPTION
This adds New Relic 3.28 for Java. In one of our New Relic tutorials, we make people write their own package script. Unfortunately, that needed some extra touches because of a Java `IOException`. This fixes the package script in that tutorial.

I tried to make this package generic and not hard-code keys or app names. That means, in order to use this package, you'll need to create your Java app like this.

```
apc app create my-app --depends-on package.newrelic-java-3.28.0 --set-env 'JAVA_OPTS=-Dnewrelic.config.license_key=1234 -Dnewrelic.config.app_name=my-app'

# This is the important part.
# JAVA_OPTS=-Dnewrelic.config.license_key=1234 -Dnewrelic.config.app_name=my-app
```

Fixes #[ENGT-7363](https://apcera.atlassian.net/browse/ENGT-7363)

@alextoombs @lloydde @lparis @rusher81572 @tw4dl @yaso195 @zquestz