### PR TITLE
Updated the python version for s3cmd package

### DIFF
--- a/packages/s3cmd-1.6.1.conf
+++ b/packages/s3cmd-1.6.1.conf
@@ -8,7 +8,7 @@ sources [
 
 build_depends [ { package: "build-essential" } ]
 depends  [ { os: "ubuntu" }, 
-           { runtime: "python-2.7" } ]
+           { runtime: "python-2.7.9" } ]
 
 provides [ { package: "s3cmd" },
            { package: "s3cmd-1" },


### PR DESCRIPTION
We have to exactly specify the python version number for s3cmd package. Becausem  this package will not be installed correctly to the apps, if the app is using a different python package than the one used to build this package. 

@variadico