### PR TITLE
Create apache-spark-1.6.1.conf

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ application (ie, might need git to checkout a repository).
 * rabbitmq-3.5.5
 * redis-2.8.13
 * rsync-3.1.1
+* spark-1.6.1
 * subversion-1.8.9
 * subversion-1.9.3
 * tokumx-2.0.1

--- a/Verification.md
+++ b/Verification.md
@@ -224,6 +224,17 @@ the release, so only the MD5s for the latest release of the supported versions
 are available.
 
 
+Spark
+-----
+
+Spark 1.6.1 source code was downloaded from http://apache.mirror.anlx.net/spark/spark-1.6.1/spark-1.6.1-bin-hadoop2.6.tgz
+on 2016-06-29 by Earl Ruby. The MD5 sum of spark-1.6.1-bin-hadoop2.6.tgz = 667a62d7f289479a19da4b563e7151d4,
+which matches the value shown at http://www.apache.org/dist/spark/spark-1.6.1/spark-1.6.1-bin-hadoop2.6.tgz.md5.
+SHA256 of 09f3b50676abc9b3d1895773d18976953ee76945afa72fa57e6473ce4e215970 was computed by Earl Ruby, who uploaded the
+file from Apache.org into the Apcera S3 bucket https://apcera-sources.s3.amazonaws.com/spark/spark-1.6.1-bin-hadoop2.6.tgz.
+
+For an example of using the Spark package on the Apcera Platform, see https://www.apcera.com/blog/apache-spark-apcera-platform-community-edition.
+
 ZSH
 ---
 

--- a/packages/apache-spark-1.6.1.conf
+++ b/packages/apache-spark-1.6.1.conf
@@ -1,0 +1,31 @@
+name:    "spark"
+version: "1.6.1"
+
+sources [
+  {url: "http://apache.mirror.anlx.net/spark/spark-1.6.1/spark-1.6.1-bin-hadoop2.6.tgz"},
+]
+
+build_depends [
+  { package: "build-essential" }
+]
+
+depends [
+  {os: "linux"},
+  {runtime: "java-1.8"}
+]
+
+provides [
+  { runtime: "spark" },
+  { runtime: "spark-1" },
+  { runtime: "spark-1.6" },
+  { runtime: "spark-1.6.1" } ]
+
+build (
+      export INSTALLPATH=/opt/apcera/spark-1.6.1
+      tar xf spark-1.6.1-bin-hadoop2.6.tgz
+      sudo mv spark-1.6.1-bin-hadoop2.6 /opt/apcera/spark-1.6.1
+)
+
+environment {
+  "SPARK_HOME": "/opt/apcera/spark-1.6.1"
+}

--- a/packages/apache-spark-1.6.1.conf
+++ b/packages/apache-spark-1.6.1.conf
@@ -1,8 +1,12 @@
-name:    "spark"
+# For an example of using the Spark package on the Apcera Platform, see
+# https://www.apcera.com/blog/apache-spark-apcera-platform-community-edition.
+
+name:    "spark-1.6.1"
 version: "1.6.1"
 
 sources [
-  {url: "http://apache.mirror.anlx.net/spark/spark-1.6.1/spark-1.6.1-bin-hadoop2.6.tgz"},
+  {url: "https://apcera-sources.s3.amazonaws.com/spark/spark-1.6.1-bin-hadoop2.6.tgz",
+   sha256: "09f3b50676abc9b3d1895773d18976953ee76945afa72fa57e6473ce4e215970" },
 ]
 
 build_depends [


### PR DESCRIPTION
Adding a package for Spark 1.6.1, got the code from Dean's blog https://www.apcera.com/blog/apache-spark-apcera-platform-community-edition