### PR TITLE
Create mysql-client package to use in mysql-backup sample app

### DIFF
--- a/runtimes/mysql-client-5.6.31.conf
+++ b/runtimes/mysql-client-5.6.31.conf
@@ -1,0 +1,49 @@
+# Copyright 2016 Apcera Inc. All rights reserved.
+
+# Although Ubuntu has separate MySQL server and client packages, the MySQL site only 
+# provides a single tarball with all source. For jobs that just need to connect to
+# a MySQL server and run programs such as mysqldump, we install the same binaries
+# that we install for MySQL server but we don't start the server process.
+
+name:      "mysql-client-5.6.31"
+namespace: "/apcera/pkg/runtimes"
+version:   "5.6.31"
+
+sources [
+  { url: "https://s3.amazonaws.com/apcera-sources/mysql/mysql-5.6.31.tar.gz",
+    sha256: "6df1389bbf899025aee6be0f4a12b8b0135e6de7db83e3ea20201ad3633ba424" },
+]
+
+build_depends [
+  { package: "build-essential" }
+]
+
+depends [
+  { os: "ubuntu" }
+]
+
+provides [
+  { runtime: "mysql-client" },
+  { runtime: "mysql-client-5.6" },
+  { runtime: "mysql-client-5.6.31" }
+]
+
+environment {
+  "PATH": "/opt/apcera/mysql-client-5.6.31/bin:$PATH" 
+}
+
+build (
+  export INSTALLPATH=/opt/apcera/mysql-client-5.6.31
+  tar xf mysql-5.6.31.tar.gz
+  cd mysql-5.6.31 || exit
+
+  # Build mysql.
+  cmake -DCMAKE_INSTALL_PREFIX=${INSTALLPATH} -DENABLE_DOWNLOADS=1 -DCMAKE_C_FLAGS="-O3 -g -Wall -Wextra -Wformat-security -Wvla -Wwrite-strings -Wdeclaration-after-statement" -DCMAKE_CXX_FLAGS_RELWITHDEBINFO="-O3 -g -DDBUG_OFF" -DDEFAULT_CHARSET=utf8 -DDEFAULT_COLLATION=utf8_general_ci .
+  make -j4
+  make install
+
+  # Remove non-essential files.
+  rm -rf ${INSTALLPATH}/docs
+  rm -rf ${INSTALLPATH}/man
+)
+


### PR DESCRIPTION
* Created a MySQL client package.
* Used this package in the mysql-backup sample app (in place of apt-get).
* Also updated the bash_start.sh script in mysql-backup sample app so that it returns a 503 (service unavailable) and the message "First backup has not completed" if the first backup has not yet been completed.
* Updated the docs as necessary.

Fixes #ENGT-8354

I had to update 6 repos and generate 6 PRs for this sample app.

@ketandixit @lilirui @variadico @yaso195