### PR TITLE
Moved mysql-client-5.6.31 from runtimes to packages

### DIFF
--- a/packages/mysql-client-5.6.31.conf
+++ b/packages/mysql-client-5.6.31.conf
@@ -1,12 +1,16 @@
 # Copyright 2016 Apcera Inc. All rights reserved.
 
+# You must give the compiler more memory and disk.
+# apc job update /apcera/stagers::compiler --memory 4G --disk 8G
+# Otherwise, you won't be able to build this package.
+
 # Although Ubuntu has separate MySQL server and client packages, the MySQL site only 
 # provides a single tarball with all source. For jobs that just need to connect to
 # a MySQL server and run programs such as mysqldump, we install the same binaries
 # that we install for MySQL server but we don't start the server process.
 
-name:      "mysql-client-5.6.31"
-namespace: "/apcera/pkg/runtimes"
+name:      "mysql-client-5.6.31-apc1"
+namespace: "/apcera/pkg/packages"
 version:   "5.6.31"
 
 sources [
@@ -23,9 +27,9 @@ depends [
 ]
 
 provides [
-  { runtime: "mysql-client" },
-  { runtime: "mysql-client-5.6" },
-  { runtime: "mysql-client-5.6.31" }
+  { package: "mysql-client" },
+  { package: "mysql-client-5.6" },
+  { package: "mysql-client-5.6.31" }
 ]
 
 environment {


### PR DESCRIPTION
Moved mysql-client-5.6.31 from runtimes to packages

Fixes #ENGT-8354

@zquestz @ketandixit @variadico 