### PR TITLE
Add package script for minio-2016-09-11

### DIFF
--- a/packages/minio-2016-09-11.conf
+++ b/packages/minio-2016-09-11.conf
@@ -1,0 +1,36 @@
+# Copyright 2016 Apcera Inc. All rights reserved.
+#
+# Designed to be used with the following start command
+# sudo minio -C /opt/apcera/minio/config server --address ":$PORT" /opt/apcera/minio/data
+#
+# If you wish to use this with NFS, you need to mount 2 volumes. That way both the config
+# and data are persisted on restart.
+# /opt/apcera/minio/data
+# /opt/apcera/minio/config
+
+name:      "minio-2016-09-11"
+namespace: "/apcera/pkg/packages"
+
+sources [
+  { url: "https://s3.amazonaws.com/apcera-sources/minio/minio-2016-09-11.tar.gz",
+    sha256: "d875cfbd10cd85cb81dc272a358688dfb4be158c01d82066ad8c6766e84d361d" },
+]
+
+depends       [ { os: "linux" } ]
+provides      [ { package: "minio" },
+                { package: "minio-2016-09-11" } ]
+
+environment { "PATH": "/opt/apcera/minio/bin/:$PATH" }
+
+build (
+    tar -zxf minio-2016-09-11.tar.gz
+    sudo chmod +x minio
+
+    export INSTALLPATH=/opt/apcera/minio
+
+    sudo mkdir -p ${INSTALLPATH}/bin
+    sudo mkdir -p ${INSTALLPATH}/data
+    sudo mkdir -p ${INSTALLPATH}/config/.minio
+
+    sudo cp -a minio ${INSTALLPATH}/bin
+)


### PR DESCRIPTION
Adds a package script for the latest version of minio server. Docs are included at the top of the package script, and describe how to setup persistence and the logical start command to use.

Minio uses a rolling release cycle, so the package is time stamped, not versioned, as a version number is not available.

@variadico @earlruby @bwerthmann 