### PR TITLE
Add iperf3 package

### DIFF
--- a/packages/iperf-3.0.11.conf
+++ b/packages/iperf-3.0.11.conf
@@ -1,0 +1,27 @@
+name:      "iperf-3.0.11"
+namespace: "/apcera/pkg/packages"
+version:   "3.0.11"
+
+sources [
+  { url: "https://s3.amazonaws.com/apcera-sources/iperf/iperf-3.0.11.tar.gz",
+    sha256: "c774b807ea4db20e07558c47951df186b6fb1dd0cdef4282c078853ad87cc712" },
+]
+
+build_depends [ { package: "build-essential" } ]
+depends  [ { os: "linux" } ]
+
+provides [ { package: "iperf3" },
+           { package: "iperf-3.0" },
+           { package: "iperf-3.0.11" } ]
+
+environment { "PATH": "/opt/apcera/iperf-3.0.11/bin:$PATH" }
+
+build (
+      export INSTALLPATH=/opt/apcera/iperf-3.0.11/
+      tar -zxf iperf-3.0.11.tar.gz --no-same-owner
+      sudo mkdir -p ${INSTALLPATH}
+      cd iperf-3.0.11
+      ./configure --prefix=${INSTALLPATH} --without-tcltk
+      make -i
+      sudo make -i install
+)


### PR DESCRIPTION
This adds the `iperf3` package. It's version 3.0.11 because that is the version you get when you `apt-get install iperf3` on Ubuntu 16.04, which is what our `iperf` servers are running.

`iperf3` has been completely rewritten from scratch. It may solve the `iperf` performance issues described in [ENGT-9569](https://apcera.atlassian.net/browse/ENGT-9569).

PS I don't know where the kjackson03 commit came from.

@variadico 