### PR TITLE
Add ruby v2.2.5 package

### DIFF
--- a/runtimes/ruby-2.2.5.conf
+++ b/runtimes/ruby-2.2.5.conf
@@ -1,0 +1,51 @@
+name:      "ruby-2.2.5"
+namespace: "/apcera/pkg/runtimes"
+
+sources [
+  { url: "https://s3.amazonaws.com/apcera-sources/ruby/ruby-2.2.5.tar.gz",
+    sha256: "30c4b31697a4ca4ea0c8db8ad30cf45e6690a0f09687e5d483c933c03ca335e3" },
+  { url: "https://apcera-sources.s3.amazonaws.com/ruby/yaml-0.1.6.tar.gz",
+    sha256: "7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" },
+  { url: "https://s3.amazonaws.com/apcera-sources/ruby/rubygems-2.6.7.tgz",
+    sha256: "0f07ef521859a4df4e0c0dbb90b05e76da9bcb64aeaff2891d8796252e156e5b" },
+  { url: "https://s3.amazonaws.com/apcera-sources/ruby/bundler-1.13.6.gem",
+    sha256: "fafd22dfed658ca0603f321bdd168ed709d7c682e61273b55637716459f2d0f7" },
+]
+
+build_depends [ { package: "build-essential" } ]
+depends       [ { os: "ubuntu" } ]
+provides      [ { runtime: "ruby" },
+                { runtime: "ruby-2.2" },
+                { runtime: "ruby-2.2.5" } ]
+
+environment { "PATH": "/opt/apcera/ruby-2.2.5/bin:$PATH" }
+
+build (
+      export BUILDPATH=`pwd`
+      export INSTALLPATH="/opt/apcera/ruby-2.2.5"
+
+      tar xzvf yaml-0.1.6.tar.gz
+      (
+          cd yaml-0.1.6
+          ./configure --disable-shared --with-pic
+          make
+      )
+
+      tar xzvf ruby-2.2.5.tar.gz
+      (
+        cd ruby-2.2.5
+        export LDFLAGS="-L${BUILDPATH}/yaml-0.1.6/src/.libs $LDFLAGS"
+        export CPPFLAGS="-I${BUILDPATH}/yaml-0.1.6/include $CPPFLAGS"
+        ./configure --prefix=${INSTALLPATH} --enable-shared --disable-install-doc
+        make
+        sudo make install
+      )
+
+      tar zxvf rubygems-2.6.7.tgz
+      (
+        cd rubygems-2.6.7
+        sudo ${INSTALLPATH}/bin/ruby setup.rb
+      )
+
+      sudo ${INSTALLPATH}/bin/gem install bundler-1.13.6.gem --no-ri --no-rdoc
+)


### PR DESCRIPTION
Since Ruby 2.2.5 was released for a while, we should have this package and maybe replace 2.2.4 in our system test.

@variadico @yaso195 @zquestz 
