### PR TITLE
Remove reference to an old version of ImageMagick from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,6 @@ application (ie, might need git to checkout a repository).
 * git-2.3.1
 * git-2.8.0
 * gnatsd-0.7.2
-* imagemagick-6.8.9-6-apc2
 * imagemagick-6.9.6-5
 * iperf-2.0.5
 * ltp-2016.05.10


### PR DESCRIPTION
Left this reference behind in the README after I updated ImageMagick in #144. Whoops!