### PR TITLE
Update s3cmd

### DIFF
--- a/packages/s3cmd-1.6.1-apc2.conf
+++ b/packages/s3cmd-1.6.1-apc2.conf
@@ -1,4 +1,4 @@
-name:      "s3cmd-1.6.1"
+name:      "s3cmd-1.6.1-apc2"
 namespace: "/apcera/pkg/packages"
 
 sources [
@@ -7,8 +7,8 @@ sources [
 ]
 
 build_depends [ { package: "build-essential" } ]
-depends  [ { os: "ubuntu" }, 
-           { runtime: "python-2.7.9" } ]
+depends  [ { os: "ubuntu" },
+           { runtime: "python-2.7" } ]
 
 provides [ { package: "s3cmd" },
            { package: "s3cmd-1" },


### PR DESCRIPTION
This loosens the Python requirement on the `s3cmd` package. It shouldn't require exactly Python 2.7.9.