### PR TITLE
added /opt/apcera/go/bin to environment path to better support tools

### DIFF
--- a/runtimes/go-1.5.1.conf
+++ b/runtimes/go-1.5.1.conf
@@ -15,7 +15,7 @@ depends  [ { os: "ubuntu" },
 provides [ { runtime: "go" },
            { runtime: "go-1.5.1" } ]
 
-environment { "PATH":    "/opt/apcera/go1.5.1.linux-amd64/bin:$PATH",
+environment { "PATH":    "/opt/apcera/go1.5.1.linux-amd64/bin:/opt/apcera/go/bin:$PATH",
               "GOROOT":  "/opt/apcera/go1.5.1.linux-amd64",
               "GOPATH":  "/opt/apcera/go" }
 
@@ -34,7 +34,7 @@ build (
       # Install godeps
       export PATH=$INSTALLPATH/bin:$PATH
       export GOROOT=$INSTALLPATH
-      go get github.com/tools/godep
+      go get -u github.com/tools/godep
 
       sudo chown -R runner:runner $GOPATH
       sudo chown -R runner:runner $INSTALLPATH

--- a/runtimes/go-1.5.3.conf
+++ b/runtimes/go-1.5.3.conf
@@ -16,7 +16,7 @@ provides [ { runtime: "go" },
            { runtime: "go-1.5" },
            { runtime: "go-1.5.3" } ]
 
-environment { "PATH":    "/opt/apcera/go1.5.3.linux-amd64/bin:$PATH",
+environment { "PATH":    "/opt/apcera/go1.5.3.linux-amd64/bin:/opt/apcera/go/bin:$PATH",
               "GOROOT":  "/opt/apcera/go1.5.3.linux-amd64",
               "GOPATH":  "/opt/apcera/go" }
 
@@ -35,7 +35,7 @@ build (
       # Install godeps
       export PATH=$INSTALLPATH/bin:$PATH
       export GOROOT=$INSTALLPATH
-      go get github.com/tools/godep
+      go get -u github.com/tools/godep
 
       sudo chown -R runner:runner $GOPATH
       sudo chown -R runner:runner $INSTALLPATH

--- a/runtimes/go-1.5.4.conf
+++ b/runtimes/go-1.5.4.conf
@@ -16,7 +16,7 @@ provides [ { runtime: "go" },
            { runtime: "go-1.5" },
            { runtime: "go-1.5.4" } ]
 
-environment { "PATH":    "/opt/apcera/go1.5.4.linux-amd64/bin:$PATH",
+environment { "PATH":    "/opt/apcera/go1.5.4.linux-amd64/bin:/opt/apcera/go/bin:$PATH",
               "GOROOT":  "/opt/apcera/go1.5.4.linux-amd64",
               "GOPATH":  "/opt/apcera/go" }
 
@@ -32,11 +32,11 @@ build (
       sudo mkdir -p ${INSTALLPATH}
       sudo cp -a go/. ${INSTALLPATH}
 
-      # Install godeps
+      # Install godeps and other dependency tools
       export PATH=$INSTALLPATH/bin:$PATH
       export GOROOT=$INSTALLPATH
-      go get github.com/tools/godep
-
+      go get -u github.com/tools/godep
+      
       sudo chown -R runner:runner $GOPATH
       sudo chown -R runner:runner $INSTALLPATH
 )

--- a/runtimes/go-1.6.2.conf
+++ b/runtimes/go-1.6.2.conf
@@ -16,7 +16,7 @@ provides [ { runtime: "go" },
            { runtime: "go-1.6" },
            { runtime: "go-1.6.2" } ]
 
-environment { "PATH":    "/opt/apcera/go1.6.2.linux-amd64/go/bin:$PATH",
+environment { "PATH":    "/opt/apcera/go1.6.2.linux-amd64/go/bin:/opt/apcera/go/bin:$PATH",
               "GOROOT":  "/opt/apcera/go1.6.2.linux-amd64/go",
               "GOPATH":  "/opt/apcera/go" }
 
@@ -35,7 +35,7 @@ build (
   cd $GOPATH || exit
   mkdir bin pkg src
 
-  go get github.com/tools/godep
+  go get -u github.com/tools/godep
 
   chown -R runner:runner $INSTALLPATH
   chown -R runner:runner $GOPATH

--- a/runtimes/go-1.6.3.conf
+++ b/runtimes/go-1.6.3.conf
@@ -16,7 +16,7 @@ provides [ { runtime: "go" },
            { runtime: "go-1.6" },
            { runtime: "go-1.6.3" } ]
 
-environment { "PATH":    "/opt/apcera/go1.6.3.linux-amd64/go/bin:$PATH",
+environment { "PATH":    "/opt/apcera/go1.6.3.linux-amd64/go/bin:/opt/apcera/go/bin:$PATH",
               "GOROOT":  "/opt/apcera/go1.6.3.linux-amd64/go",
               "GOPATH":  "/opt/apcera/go" }
 
@@ -34,7 +34,7 @@ build (
   cd $GOPATH || exit
   mkdir bin pkg src
 
-  go get github.com/tools/godep
+  go get -u github.com/tools/godep
 
   chown -R runner:runner $INSTALLPATH
   chown -R runner:runner $GOPATH

--- a/runtimes/go-1.6.conf
+++ b/runtimes/go-1.6.conf
@@ -15,7 +15,7 @@ depends  [ { os: "ubuntu" },
 provides [ { runtime: "go" },
            { runtime: "go-1.6" } ]
 
-environment { "PATH":    "/opt/apcera/go1.6.linux-amd64/go/bin:$PATH",
+environment { "PATH":    "/opt/apcera/go1.6.linux-amd64/go/bin:/opt/apcera/go/bin:$PATH",
               "GOROOT":  "/opt/apcera/go1.6.linux-amd64/go",
               "GOPATH":  "/opt/apcera/go" }
 

--- a/runtimes/go-1.7.4.conf
+++ b/runtimes/go-1.7.4.conf
@@ -21,7 +21,7 @@ provides [
 ]
 
 environment {
-  "PATH": "/opt/apcera/go1.7.4.linux-amd64/go/bin:$PATH",
+  "PATH": "/opt/apcera/go1.7.4.linux-amd64/go/bin:/opt/apcera/go/bin:$PATH",
   "GOROOT": "/opt/apcera/go1.7.4.linux-amd64/go",
   "GOPATH": "/opt/apcera/go",
 }


### PR DESCRIPTION
I only added to the environment path.  I did not add extra go vendoring/versioning tools at this time since doing so seems to increase size of the go runtime packages and some packages created from them.  We can always add the extra tools later if desired.