### PR TITLE
ENGT-10684: Add apt-mirror

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ application (ie, might need git to checkout a repository).
 * apache-tomcat-8.0.30
 * apache-tomcat-8.0.33
 * apc-0.16.0
+* apt-mirror-0.5.3
 * bonnie-1.97.3
 * bzr-2.6.0
 * chown-chgrp-chmod-0.0.1

--- a/packages/apt-mirror-0.5.3.conf
+++ b/packages/apt-mirror-0.5.3.conf
@@ -1,0 +1,23 @@
+name:      "apt-mirror-0.5.3"
+namespace: "/apcera/pkg/packages"
+
+sources [
+  { url: "https://github.com/apt-mirror/apt-mirror/archive/0.5.3.zip",
+    sha256: "ae8dea80c57dd2538b661aac3fb11b547ddfbd4f6e63ebd18a6e50035cd941ad" },
+]
+
+build_depends [ { package: "build-essential" } ]
+depends       [ { os: "ubuntu" } ]
+provides      [ { package: "apt-mirror" }, { package: "apt-mirror-0.5.3"} ]
+
+environment { "PATH": "/opt/apcera/apt-mirror-0.5.3/bin:$PATH" }
+
+build (
+    export INSTALLPATH=/opt/apcera/apt-mirror-0.5.3
+
+    unzip 0.5.3.zip
+    cd apt-mirror-0.5.3
+
+    sudo mkdir -p ${INSTALLPATH}
+    sudo PREFIX=/ DESTDIR=${INSTALLPATH} make install
+)


### PR DESCRIPTION
Use apt-mirror to mirror the Ubuntu repos. This is an internal package, it does not need to be a standard part of our distributed package set.