### PR TITLE
Add --no-virt to livemedia-creator options

### DIFF
--- a/os/Vagrantfile
+++ b/os/Vagrantfile
@@ -15,35 +15,21 @@ Vagrant.configure("2") do |config|
 
   config.vm.provision "shell", inline: <<-SHELL
     echo "Install yum deps"
-    yum install -y libguestfs-tools-c
     yum install -y lorax
-    yum install -y virt-install
-
-    echo "Starting virtualization daemon"
-    systemctl enable libvirtd.service
-    systemctl start libvirtd.service
-    systemctl status libvirtd.service
+    yum install -y anaconda
 
     cd /root || exit 1
     cp /vagrant/defaultnet.xml /root
     cp /vagrant/centos-7.ks /root
 
-    # qemu user needs to be able to read files in /root.
-    usermod -aG root qemu
-
     # CentOS targz will be placed here. Make sure it exists.
     mkdir -p /var/tmp
-
-    virsh net-define defaultnet.xml
-    virsh net-autostart default
-    virsh net-start default
 
     echo "Downloading CentOS bootstrap ISO"
     curl --silent --remote-name https://s3.amazonaws.com/apcera-sources/centos/centos-7-boot.iso
 
     echo "Creating CentOS targz"
-    echo "This might take about 1 hour"
-    livemedia-creator --iso centos-7-boot.iso --ks centos-7.ks --make-tar --compression gzip --image-name centos-7.tar.gz
+    livemedia-creator --iso centos-7-boot.iso --ks centos-7.ks --make-tar --compression gzip --image-name centos-7.tar.gz --no-virt
     cp /var/tmp/centos-7.tar.gz /vagrant
     echo "Done! Check the current dir for 'centos-7.tar.gz'!"
   SHELL

--- a/os/centos-7.ks
+++ b/os/centos-7.ks
@@ -2,7 +2,7 @@
 # https://github.com/CentOS/sig-cloud-instance-build/tree/c8e7802e29fc836f900541b58d4d5bc5880abc01/docker
 
 # Basic setup information.
-url --url="http://mirrors.kernel.org/centos/7/os/x86_64/"
+url --url="https://repository.prod.apcera.net/latest/centos/7/os/x84_64/"
 install
 keyboard us
 rootpw --lock --iscrypted locked
@@ -15,8 +15,8 @@ bootloader --disable
 lang en_US
 
 # Repositories to use
-repo --name="CentOS" --baseurl=http://mirror.centos.org/centos/7/os/x86_64/ --cost=100
-repo --name="Updates" --baseurl=http://mirror.centos.org/centos/7/updates/x86_64/ --cost=100
+repo --name="CentOS" --baseurl=https://repository.prod.apcera.net/latest/centos/7/os/x84_64/ --cost=100
+repo --name="Updates" --baseurl=https://repository.prod.apcera.net/latest/centos/7/updates/x84_64/ --cost=100
 
 # Disk setup.
 zerombr
@@ -125,4 +125,5 @@ rm /var/run/nologin
 /bin/date +%Y%m%d_%H%M > /etc/BUILDTIME
 
 "" > /etc/machine-id
+rm /root/anaconda-ks.cfg /anaconda-post.log
 %end

--- a/os/centos-7.ks
+++ b/os/centos-7.ks
@@ -56,6 +56,7 @@ libgcc
 libicu
 ncurses-libs
 net-tools
+nmap-ncat
 openssh-clients
 openssl-libs
 passwd
@@ -125,5 +126,4 @@ rm /var/run/nologin
 /bin/date +%Y%m%d_%H%M > /etc/BUILDTIME
 
 "" > /etc/machine-id
-rm /root/anaconda-ks.cfg /anaconda-post.log
 %end


### PR DESCRIPTION
This simplifies the creation of the CentOS tarball by running the script
that creates the tarball directly on the Vagrant-managed VM rather than
creating another VM inside that one (I was unable to generate a tarball
without this option as livemedia-creator simply hung indefinitely).