### PR TITLE
Add apache v2.4.27 package

### DIFF
--- a/packages/apache-2.4.27.conf
+++ b/packages/apache-2.4.27.conf
@@ -1,0 +1,56 @@
+name:      "apache-2.4.27"
+namespace: "/apcera/pkg/packages"
+
+sources [
+  { url: "https://apcera-sources.s3.amazonaws.com/apache/httpd-2.4.27.tar.gz",
+    sha256: "346dd3d016ae5d7101016e68805150bdce9040a8d246c289aa70e68a7cd86b66" },
+  { url: "https://apcera-sources.s3.amazonaws.com/apache/apr-1.6.2.tar.gz",
+    sha256: "4fc24506c968c5faf57614f5d0aebe0e9d0b90afa47a883e1a1ca94f15f4a42e" },
+  { url: "https://apcera-sources.s3.amazonaws.com/apache/apr-util-1.6.0.tar.gz",
+    sha256: "483ef4d59e6ac9a36c7d3fd87ad7b9db7ad8ae29c06b9dd8ff22dda1cc416389" },
+]
+
+build_depends [ { package: "build-essential" } ]
+depends       [ { os: "ubuntu" } ]
+provides      [ { package: "apache" },
+                { package: "apache-2.4" },
+                { package: "apache-2.4.27" } ]
+
+environment { "PATH":                "/opt/apcera/apache-2.4.27/bin:$PATH",
+              "APACHE_ROOT":         "/opt/apcera/apache-2.4.27",
+              "APACHE_MODULES_PATH": "/opt/apcera/apache-2.4.27/modules" }
+
+build (
+      export APR_INSTALL_PATH=/opt/apcera/apr-1.6.2/
+      tar -zxf apr-1.6.2.tar.gz
+      sudo mkdir -p ${APR_INSTALL_PATH}
+      cd apr-1.6.2
+      echo "Configuring"
+      ./configure --prefix=${APR_INSTALL_PATH}
+      echo "Running Make"
+      make
+      echo "Running Make Install"
+      sudo make install
+
+      cd ..
+      export APR_UTIL_INSTALL_PATH=/opt/apcera/apr-util-1.6.0/
+      tar -zxf apr-util-1.6.0.tar.gz
+      sudo mkdir -p ${APR_UTIL_INSTALL_PATH}
+      cd apr-util-1.6.0
+      echo "Configuring"
+      ./configure --prefix=${APR_UTIL_INSTALL_PATH} --with-apr=${APR_INSTALL_PATH}
+      echo "Running Make"
+      make
+      echo "Running Make Install"
+      sudo make install
+      export INSTALLPATH=/opt/apcera/apache-2.4.27
+
+      cd ..
+      tar xvzf httpd-2.4.27.tar.gz
+      cd httpd-2.4.27
+      ./configure --prefix=${INSTALLPATH} --with-apr=${APR_INSTALL_PATH} --with-apr-util=${APR_UTIL_INSTALL_PATH} --enable-rewrite
+      make
+      sudo make install
+
+      sudo rm -f ${INSTALLPATH}/cgi-bin/*
+)


### PR DESCRIPTION
Includes updates to `apr` (1.6.2) and `apr-util` (1.6.0).

This is part of the resolution for [ENGT-10724](https://apcera.atlassian.net/browse/ENGT-10724).
Companion PR to [`continuum-stagers` #100](https://github.com/apcera/continuum-stagers/pull/100).